### PR TITLE
Allow energy as input to plotters

### DIFF
--- a/src/easydynamics/analysis/analysis.py
+++ b/src/easydynamics/analysis/analysis.py
@@ -150,6 +150,7 @@ class Analysis(AnalysisBase):
     def calculate(
         self,
         Q_index: int | None = None,
+        energy: sc.Variable | None = None,
     ) -> list[np.ndarray] | np.ndarray:
         """Calculate model data for a specific Q index. If Q_index is
         None, calculate for all Q indices and return a list of arrays.
@@ -167,12 +168,14 @@ class Analysis(AnalysisBase):
         Raises:
             IndexError: If Q_index is not None and is out of bounds.
         """
+        if energy is None:
+            energy = self.energy
 
         if Q_index is None:
-            return [analysis.calculate() for analysis in self.analysis_list]
+            return [analysis.calculate(energy=energy) for analysis in self.analysis_list]
 
         Q_index = self._verify_Q_index(Q_index)
-        return self.analysis_list[Q_index].calculate()
+        return self.analysis_list[Q_index].calculate(energy=energy)
 
     def fit(
         self,
@@ -224,6 +227,7 @@ class Analysis(AnalysisBase):
         Q_index: int | None = None,
         plot_components: bool = True,
         add_background: bool = True,
+        energy: sc.Variable | None = None,
         **kwargs,
     ) -> InteractiveFigure:
         """Plot the experimental data and the model prediction.
@@ -260,6 +264,7 @@ class Analysis(AnalysisBase):
             return self.analysis_list[Q_index].plot_data_and_model(
                 plot_components=plot_components,
                 add_background=add_background,
+                energy=energy,
                 **kwargs,
             )
 
@@ -280,6 +285,9 @@ class Analysis(AnalysisBase):
         if not isinstance(add_background, bool):
             raise TypeError('add_background must be True or False.')
 
+        if energy is None:
+            energy = self.energy
+
         import plopp as pp
 
         plot_kwargs_defaults = {
@@ -292,11 +300,13 @@ class Analysis(AnalysisBase):
         }
         data_and_model = {
             'Data': self.experiment.binned_data,
-            'Model': self._create_model_array(),
+            'Model': self._create_model_array(energy=energy),
         }
 
         if plot_components:
-            components = self._create_components_dataset(add_background=add_background)
+            components = self._create_components_dataset(
+                add_background=add_background, energy=energy
+            )
             for key in components.keys():
                 data_and_model[key] = components[key]
                 plot_kwargs_defaults['linestyle'][key] = '--'
@@ -507,13 +517,13 @@ class Analysis(AnalysisBase):
         ws = []
 
         for analysis in self.analysis_list:
-            x, y, weight = self.experiment._extract_x_y_weights_only_finite(analysis.Q_index)
+            x, y, weight, _ = self.experiment._extract_x_y_weights_only_finite(analysis.Q_index)
             xs.append(x)
             ys.append(y)
             ws.append(weight)
 
             # Make sure the convolver is up to date for this Q index
-            analysis._convolver = analysis._create_convolver()
+            analysis._convolver = analysis._create_convolver(energy=x)
 
         mf = MultiFitter(
             fit_objects=self.analysis_list,
@@ -537,22 +547,27 @@ class Analysis(AnalysisBase):
         """
         return [analysis.as_fit_function() for analysis in self.analysis_list]
 
-    def _create_model_array(self) -> sc.DataArray:
+    def _create_model_array(self, energy: sc.Variable | None = None) -> sc.DataArray:
         """Create a scipp array for the model.
 
         Returns:
             sc.DataArray: A DataArray containing the model values, with
                 dimensions "Q" and "energy".
         """
-
-        model = sc.array(dims=['Q', 'energy'], values=self.calculate())
+        if energy is None:
+            energy = self.energy
+        model = sc.array(dims=['Q', 'energy'], values=self.calculate(energy=energy))
         model_data_array = sc.DataArray(
             data=model,
-            coords={'Q': self.Q, 'energy': self.experiment.energy},
+            coords={'Q': self.Q, 'energy': energy},
         )
         return model_data_array
 
-    def _create_components_dataset(self, add_background: bool = True) -> sc.Dataset:
+    def _create_components_dataset(
+        self,
+        add_background: bool = True,
+        energy: sc.Variable | None = None,
+    ) -> sc.Dataset:
         """Create a scipp dataset containing the individual components
         of the model for plotting.
 
@@ -571,8 +586,13 @@ class Analysis(AnalysisBase):
         if not isinstance(add_background, bool):
             raise TypeError('add_background must be True or False.')
 
+        if energy is None:
+            energy = self.energy
+
         datasets = [
-            analysis._create_components_dataset_single_Q(add_background=add_background)
+            analysis._create_components_dataset_single_Q(
+                add_background=add_background, energy=energy
+            )
             for analysis in self.analysis_list
         ]
 

--- a/src/easydynamics/analysis/analysis1d.py
+++ b/src/easydynamics/analysis/analysis1d.py
@@ -63,7 +63,7 @@ class Analysis1d(AnalysisBase):
 
     def __init__(
         self,
-        display_name: str = 'MyAnalysis',
+        display_name: str = "MyAnalysis",
         unique_name: str | None = None,
         experiment: Experiment | None = None,
         sample_model: SampleModel | None = None,
@@ -202,7 +202,7 @@ class Analysis1d(AnalysisBase):
             FitResults: The result of the fit.
         """
         if self._experiment is None:
-            raise ValueError('No experiment is associated with this Analysis.')
+            raise ValueError("No experiment is associated with this Analysis.")
 
         # Create convolver once to reuse during fitting
         self._convolver = self._create_convolver()
@@ -286,13 +286,13 @@ class Analysis1d(AnalysisBase):
         import plopp as pp
 
         if self.experiment.data is None:
-            raise ValueError('No data to plot. Please load data first.')
+            raise ValueError("No data to plot. Please load data first.")
 
         energy = self._verify_energy(energy)
         if energy is None:
             energy = self._masked_energy
 
-        data = self.experiment.data['Q', self.Q_index]
+        data = self.experiment.data["Q", self.Q_index]
         model_array = self._create_sample_scipp_array(energy=energy)
 
         component_dataset = self._create_components_dataset_single_Q(
@@ -301,24 +301,26 @@ class Analysis1d(AnalysisBase):
 
         # Create a dataset containing the data, model, and individual
         # components for plotting.
-        data_and_model = sc.Dataset({
-            'Data': data,
-            'Model': model_array,
-        })
+        data_and_model = sc.Dataset(
+            {
+                "Data": data,
+                "Model": model_array,
+            }
+        )
 
         data_and_model = sc.merge(data_and_model, component_dataset)
         plot_kwargs_defaults = {
-            'title': self.display_name,
-            'linestyle': {'Data': 'none', 'Model': '-'},
-            'marker': {'Data': 'o', 'Model': 'none'},
-            'color': {'Data': 'black', 'Model': 'red'},
-            'markerfacecolor': {'Data': 'none', 'Model': 'none'},
+            "title": self.display_name,
+            "linestyle": {"Data": "none", "Model": "-"},
+            "marker": {"Data": "o", "Model": "none"},
+            "color": {"Data": "black", "Model": "red"},
+            "markerfacecolor": {"Data": "none", "Model": "none"},
         }
 
         if plot_components:
             for comp_name in component_dataset.keys():
-                plot_kwargs_defaults['linestyle'][comp_name] = '--'
-                plot_kwargs_defaults['marker'][comp_name] = None
+                plot_kwargs_defaults["linestyle"][comp_name] = "--"
+                plot_kwargs_defaults["marker"][comp_name] = None
 
         # Overwrite defaults with any user-provided kwargs
         plot_kwargs_defaults.update(kwargs)
@@ -344,14 +346,15 @@ class Analysis1d(AnalysisBase):
             ValueError: If the Q index is not set.
         """
         if self._Q_index is None:
-            raise ValueError('Q_index must be set.')
+            raise ValueError("Q_index must be set.")
         return self._Q_index
 
     def _on_Q_index_changed(self) -> None:
         """Handle changes to the Q index.
 
         This method is called whenever the Q index is changed. It
-        updates the Convolution object for the new Q index. =
+        updates the Convolution object for the new Q index and the
+        masked energy from the experiment for the new Q index.
         """
         masked_energy = self.experiment.get_masked_energy(Q_index=self._Q_index)
         self._masked_energy = masked_energy
@@ -369,7 +372,9 @@ class Analysis1d(AnalysisBase):
         """
 
         if energy is not None and not isinstance(energy, sc.Variable):
-            raise TypeError(f'Energy must be a sc.Variable or None. Got {type(energy)}.')
+            raise TypeError(
+                f"Energy must be a sc.Variable or None. Got {type(energy)}."
+            )
         return energy
 
     #############
@@ -427,11 +432,11 @@ class Analysis1d(AnalysisBase):
                 energy_offset.convert_unit(energy.unit)
             except Exception as e:
                 raise UnitError(
-                    f'Energy and energy offset must have compatible units. '
-                    f'Got {energy.unit} and {energy_offset.unit}.'
+                    f"Energy and energy offset must have compatible units. "
+                    f"Got {energy.unit} and {energy_offset.unit}."
                 ) from e
 
-        energy_with_offset = energy.copy()
+        energy_with_offset = energy.copy(deep=True)
         energy_with_offset.values -= energy_offset.value
 
         # If there are no components, return zero
@@ -453,7 +458,9 @@ class Analysis1d(AnalysisBase):
         # performance is not important.
 
         # We don't create a convolver if the resolution is empty.
-        resolution = self.instrument_model.resolution_model.get_component_collection(Q_index)
+        resolution = self.instrument_model.resolution_model.get_component_collection(
+            Q_index
+        )
         if resolution.is_empty:
             return components.evaluate(energy_with_offset)
 
@@ -524,8 +531,10 @@ class Analysis1d(AnalysisBase):
             np.ndarray: The evaluated background contribution.
         """
         Q_index = self._require_Q_index()
-        background_components = self.instrument_model.background_model.get_component_collection(
-            Q_index=Q_index
+        background_components = (
+            self.instrument_model.background_model.get_component_collection(
+                Q_index=Q_index
+            )
         )
         return self._evaluate_components(
             components=background_components,
@@ -586,8 +595,8 @@ class Analysis1d(AnalysisBase):
         if sample_components.is_empty:
             return None
 
-        resolution_components = self.instrument_model.resolution_model.get_component_collection(
-            Q_index
+        resolution_components = (
+            self.instrument_model.resolution_model.get_component_collection(Q_index)
         )
         if resolution_components.is_empty:
             return None
@@ -655,7 +664,9 @@ class Analysis1d(AnalysisBase):
         )
         return self._to_scipp_array(values=values, energy=energy)
 
-    def _create_sample_scipp_array(self, energy: sc.Variable | None = None) -> sc.DataArray:
+    def _create_sample_scipp_array(
+        self, energy: sc.Variable | None = None
+    ) -> sc.DataArray:
         """Create a scipp DataArray for the full sample model including
         background.
 
@@ -694,22 +705,28 @@ class Analysis1d(AnalysisBase):
             Q_index=self.Q_index
         ).components
 
-        background_components = self.instrument_model.background_model.get_component_collection(
-            Q_index=self.Q_index
-        ).components
+        background_components = (
+            self.instrument_model.background_model.get_component_collection(
+                Q_index=self.Q_index
+            ).components
+        )
 
         if energy is None:
             energy = self._masked_energy
 
-        background = self._evaluate_background(energy=energy) if add_background else None
+        background = (
+            self._evaluate_background(energy=energy) if add_background else None
+        )
 
         for component in sample_components:
             scipp_arrays[component.display_name] = self._create_component_scipp_array(
                 component=component, background=background, energy=energy
             )
         for component in background_components:
-            scipp_arrays[component.display_name] = self._create_background_component_scipp_array(
-                component=component, energy=energy
+            scipp_arrays[component.display_name] = (
+                self._create_background_component_scipp_array(
+                    component=component, energy=energy
+                )
             )
         return sc.Dataset(scipp_arrays)
 
@@ -731,9 +748,9 @@ class Analysis1d(AnalysisBase):
         if energy is None:
             energy = self._masked_energy
         return sc.DataArray(
-            data=sc.array(dims=['energy'], values=values),
+            data=sc.array(dims=["energy"], values=values),
             coords={
-                'energy': energy,
-                'Q': self.Q[self.Q_index],
+                "energy": energy,
+                "Q": self.Q[self.Q_index],
             },
         )

--- a/src/easydynamics/analysis/analysis1d.py
+++ b/src/easydynamics/analysis/analysis1d.py
@@ -8,7 +8,6 @@ from easyscience.fitting.minimizers.utils import FitResults
 from easyscience.variable import DescriptorNumber
 from easyscience.variable import Parameter
 from plopp.backends.matplotlib.figure import InteractiveFigure
-from scipp import UnitError
 
 from easydynamics.analysis.analysis_base import AnalysisBase
 from easydynamics.convolution.convolution import Convolution
@@ -63,7 +62,7 @@ class Analysis1d(AnalysisBase):
 
     def __init__(
         self,
-        display_name: str = "MyAnalysis",
+        display_name: str = 'MyAnalysis',
         unique_name: str | None = None,
         experiment: Experiment | None = None,
         sample_model: SampleModel | None = None,
@@ -202,7 +201,7 @@ class Analysis1d(AnalysisBase):
             FitResults: The result of the fit.
         """
         if self._experiment is None:
-            raise ValueError("No experiment is associated with this Analysis.")
+            raise ValueError('No experiment is associated with this Analysis.')
 
         # Create convolver once to reuse during fitting
         self._convolver = self._create_convolver()
@@ -286,13 +285,13 @@ class Analysis1d(AnalysisBase):
         import plopp as pp
 
         if self.experiment.data is None:
-            raise ValueError("No data to plot. Please load data first.")
+            raise ValueError('No data to plot. Please load data first.')
 
         energy = self._verify_energy(energy)
         if energy is None:
             energy = self._masked_energy
 
-        data = self.experiment.data["Q", self.Q_index]
+        data = self.experiment.data['Q', self.Q_index]
         model_array = self._create_sample_scipp_array(energy=energy)
 
         component_dataset = self._create_components_dataset_single_Q(
@@ -301,26 +300,24 @@ class Analysis1d(AnalysisBase):
 
         # Create a dataset containing the data, model, and individual
         # components for plotting.
-        data_and_model = sc.Dataset(
-            {
-                "Data": data,
-                "Model": model_array,
-            }
-        )
+        data_and_model = sc.Dataset({
+            'Data': data,
+            'Model': model_array,
+        })
 
         data_and_model = sc.merge(data_and_model, component_dataset)
         plot_kwargs_defaults = {
-            "title": self.display_name,
-            "linestyle": {"Data": "none", "Model": "-"},
-            "marker": {"Data": "o", "Model": "none"},
-            "color": {"Data": "black", "Model": "red"},
-            "markerfacecolor": {"Data": "none", "Model": "none"},
+            'title': self.display_name,
+            'linestyle': {'Data': 'none', 'Model': '-'},
+            'marker': {'Data': 'o', 'Model': 'none'},
+            'color': {'Data': 'black', 'Model': 'red'},
+            'markerfacecolor': {'Data': 'none', 'Model': 'none'},
         }
 
         if plot_components:
             for comp_name in component_dataset.keys():
-                plot_kwargs_defaults["linestyle"][comp_name] = "--"
-                plot_kwargs_defaults["marker"][comp_name] = None
+                plot_kwargs_defaults['linestyle'][comp_name] = '--'
+                plot_kwargs_defaults['marker'][comp_name] = None
 
         # Overwrite defaults with any user-provided kwargs
         plot_kwargs_defaults.update(kwargs)
@@ -346,7 +343,7 @@ class Analysis1d(AnalysisBase):
             ValueError: If the Q index is not set.
         """
         if self._Q_index is None:
-            raise ValueError("Q_index must be set.")
+            raise ValueError('Q_index must be set.')
         return self._Q_index
 
     def _on_Q_index_changed(self) -> None:
@@ -372,10 +369,40 @@ class Analysis1d(AnalysisBase):
         """
 
         if energy is not None and not isinstance(energy, sc.Variable):
-            raise TypeError(
-                f"Energy must be a sc.Variable or None. Got {type(energy)}."
-            )
+            raise TypeError(f'Energy must be a sc.Variable or None. Got {type(energy)}.')
         return energy
+
+    def _calculate_energy_with_offset(
+        self,
+        energy: sc.Variable,
+        energy_offset: sc.Variable,
+    ) -> sc.Variable:
+        """Calculate the energy grid with the energy offset applied.
+
+        Args:
+            energy (sc.Variable): The energy grid to apply the offset to.
+            energy_offset (Parameter): The energy offset to apply.
+
+        Returns:
+            sc.Variable: The energy grid with the offset applied.
+
+        Raises:
+            sc.UnitError: If the energy and energy offset have
+                incompatible units.
+        """
+
+        if energy.unit != energy_offset.unit:
+            try:
+                energy_offset.convert_unit(str(energy.unit))
+            except Exception as e:
+                raise sc.UnitError(
+                    f'Energy and energy offset must have compatible units. '
+                    f'Got {energy.unit} and {energy_offset.unit}.'
+                ) from e
+
+        energy_with_offset = energy.copy(deep=True)
+        energy_with_offset.values -= energy_offset.value
+        return energy_with_offset
 
     #############
     # Private methods: evaluation
@@ -426,18 +453,10 @@ class Analysis1d(AnalysisBase):
             energy = self._masked_energy
 
         energy_offset = self.instrument_model.get_energy_offset_at_Q(Q_index)
-
-        if energy.unit != energy_offset.unit:
-            try:
-                energy_offset.convert_unit(energy.unit)
-            except Exception as e:
-                raise UnitError(
-                    f"Energy and energy offset must have compatible units. "
-                    f"Got {energy.unit} and {energy_offset.unit}."
-                ) from e
-
-        energy_with_offset = energy.copy(deep=True)
-        energy_with_offset.values -= energy_offset.value
+        energy_with_offset = self._calculate_energy_with_offset(
+            energy=energy,
+            energy_offset=energy_offset,
+        )
 
         # If there are no components, return zero
         if isinstance(components, ComponentCollection) and components.is_empty:
@@ -458,9 +477,7 @@ class Analysis1d(AnalysisBase):
         # performance is not important.
 
         # We don't create a convolver if the resolution is empty.
-        resolution = self.instrument_model.resolution_model.get_component_collection(
-            Q_index
-        )
+        resolution = self.instrument_model.resolution_model.get_component_collection(Q_index)
         if resolution.is_empty:
             return components.evaluate(energy_with_offset)
 
@@ -531,10 +548,8 @@ class Analysis1d(AnalysisBase):
             np.ndarray: The evaluated background contribution.
         """
         Q_index = self._require_Q_index()
-        background_components = (
-            self.instrument_model.background_model.get_component_collection(
-                Q_index=Q_index
-            )
+        background_components = self.instrument_model.background_model.get_component_collection(
+            Q_index=Q_index
         )
         return self._evaluate_components(
             components=background_components,
@@ -595,8 +610,8 @@ class Analysis1d(AnalysisBase):
         if sample_components.is_empty:
             return None
 
-        resolution_components = (
-            self.instrument_model.resolution_model.get_component_collection(Q_index)
+        resolution_components = self.instrument_model.resolution_model.get_component_collection(
+            Q_index
         )
         if resolution_components.is_empty:
             return None
@@ -664,9 +679,7 @@ class Analysis1d(AnalysisBase):
         )
         return self._to_scipp_array(values=values, energy=energy)
 
-    def _create_sample_scipp_array(
-        self, energy: sc.Variable | None = None
-    ) -> sc.DataArray:
+    def _create_sample_scipp_array(self, energy: sc.Variable | None = None) -> sc.DataArray:
         """Create a scipp DataArray for the full sample model including
         background.
 
@@ -705,28 +718,22 @@ class Analysis1d(AnalysisBase):
             Q_index=self.Q_index
         ).components
 
-        background_components = (
-            self.instrument_model.background_model.get_component_collection(
-                Q_index=self.Q_index
-            ).components
-        )
+        background_components = self.instrument_model.background_model.get_component_collection(
+            Q_index=self.Q_index
+        ).components
 
         if energy is None:
             energy = self._masked_energy
 
-        background = (
-            self._evaluate_background(energy=energy) if add_background else None
-        )
+        background = self._evaluate_background(energy=energy) if add_background else None
 
         for component in sample_components:
             scipp_arrays[component.display_name] = self._create_component_scipp_array(
                 component=component, background=background, energy=energy
             )
         for component in background_components:
-            scipp_arrays[component.display_name] = (
-                self._create_background_component_scipp_array(
-                    component=component, energy=energy
-                )
+            scipp_arrays[component.display_name] = self._create_background_component_scipp_array(
+                component=component, energy=energy
             )
         return sc.Dataset(scipp_arrays)
 
@@ -748,9 +755,9 @@ class Analysis1d(AnalysisBase):
         if energy is None:
             energy = self._masked_energy
         return sc.DataArray(
-            data=sc.array(dims=["energy"], values=values),
+            data=sc.array(dims=['energy'], values=values),
             coords={
-                "energy": energy,
-                "Q": self.Q[self.Q_index],
+                'energy': energy,
+                'Q': self.Q[self.Q_index],
             },
         )

--- a/src/easydynamics/analysis/analysis1d.py
+++ b/src/easydynamics/analysis/analysis1d.py
@@ -8,6 +8,7 @@ from easyscience.fitting.minimizers.utils import FitResults
 from easyscience.variable import DescriptorNumber
 from easyscience.variable import Parameter
 from plopp.backends.matplotlib.figure import InteractiveFigure
+from scipp import UnitError
 
 from easydynamics.analysis.analysis_base import AnalysisBase
 from easydynamics.convolution.convolution import Convolution
@@ -103,6 +104,12 @@ class Analysis1d(AnalysisBase):
 
         self._Q_index = self._verify_Q_index(Q_index)
 
+        if self._Q_index is not None and self.experiment is not None:
+            masked_energy = self.experiment.get_masked_energy(Q_index=self._Q_index)
+            self._masked_energy = masked_energy
+        else:
+            self._masked_energy = None
+
         self._fit_result = None
         if self._Q_index is not None:
             self._convolver = self._create_convolver()
@@ -138,29 +145,39 @@ class Analysis1d(AnalysisBase):
     # Other methods
     #############
 
-    def calculate(self) -> np.ndarray:
+    def calculate(self, energy: sc.Variable | None = None) -> np.ndarray:
         """Calculate the model prediction for the chosen Q index. Makes
         sure the convolver is up to date before calculating.
 
+        Args:
+            energy (sc.Variable | None): Optional energy grid to use for
+                calculation. If None, the energy grid from the experiment
+                is used.
+
         Returns:
             np.ndarray: The calculated model prediction.
         """
+        energy = self._verify_energy(energy)
+        self._convolver = self._create_convolver(energy=energy)
 
-        self._convolver = self._create_convolver()
+        return self._calculate(energy=energy)
 
-        return self._calculate()
-
-    def _calculate(self) -> np.ndarray:
+    def _calculate(self, energy: sc.Variable | None = None) -> np.ndarray:
         """Calculate the model prediction for the chosen Q index. Does
         not check if the convolver is up to date.
 
+        Args:
+            energy (sc.Variable | None): Optional energy grid to use for
+                calculation. If None, the energy grid from the experiment
+                is used.
+
         Returns:
             np.ndarray: The calculated model prediction.
         """
 
-        sample_intensity = self._evaluate_sample()
+        sample_intensity = self._evaluate_sample(energy=energy)
 
-        background_intensity = self._evaluate_background()
+        background_intensity = self._evaluate_background(energy=energy)
 
         sample_plus_background = sample_intensity + background_intensity
 
@@ -195,7 +212,7 @@ class Analysis1d(AnalysisBase):
             fit_function=self.as_fit_function(),
         )
 
-        x, y, weights = self.experiment._extract_x_y_weights_only_finite(
+        x, y, weights, _ = self.experiment._extract_x_y_weights_only_finite(
             Q_index=self._require_Q_index()
         )
         fit_result = fitter.fit(x=x, y=y, weights=weights)
@@ -242,7 +259,8 @@ class Analysis1d(AnalysisBase):
     def plot_data_and_model(
         self,
         plot_components: bool = True,
-        add_background=True,
+        add_background: bool = True,
+        energy: sc.Variable | None = None,
         **kwargs,
     ) -> InteractiveFigure:
         """Plot the experimental data and the model prediction for the
@@ -256,6 +274,9 @@ class Analysis1d(AnalysisBase):
                 components of the model. Default is True.
             add_background (bool): Whether to add the background to the
                 model prediction when plotting individual components.
+            energy (sc.Variable | None): Optional energy grid to use for
+                plotting. If None, the energy grid from the experiment
+                is used.
             kwargs (dict): Keyword arguments to pass to the plotting
                 function.
 
@@ -267,10 +288,16 @@ class Analysis1d(AnalysisBase):
         if self.experiment.data is None:
             raise ValueError('No data to plot. Please load data first.')
 
-        data = self.experiment.data['Q', self.Q_index]
-        model_array = self._create_sample_scipp_array()
+        energy = self._verify_energy(energy)
+        if energy is None:
+            energy = self._masked_energy
 
-        component_dataset = self._create_components_dataset_single_Q(add_background=add_background)
+        data = self.experiment.data['Q', self.Q_index]
+        model_array = self._create_sample_scipp_array(energy=energy)
+
+        component_dataset = self._create_components_dataset_single_Q(
+            add_background=add_background, energy=energy
+        )
 
         # Create a dataset containing the data, model, and individual
         # components for plotting.
@@ -324,9 +351,26 @@ class Analysis1d(AnalysisBase):
         """Handle changes to the Q index.
 
         This method is called whenever the Q index is changed. It
-        updates the Convolution object for the new Q index.
+        updates the Convolution object for the new Q index. =
         """
+        masked_energy = self.experiment.get_masked_energy(Q_index=self._Q_index)
+        self._masked_energy = masked_energy
         self._convolver = self._create_convolver()
+
+    def _verify_energy(self, energy: sc.Variable | None) -> sc.Variable | None:
+        """Verify that the provided energy is the correct type.
+
+        Args:
+            energy (sc.Variable | None): The energy to verify.
+
+        Returns:
+            sc.Variable | None: The verified energy, or None if no
+                energy is provided.
+        """
+
+        if energy is not None and not isinstance(energy, sc.Variable):
+            raise TypeError(f'Energy must be a sc.Variable or None. Got {type(energy)}.')
+        return energy
 
     #############
     # Private methods: evaluation
@@ -337,6 +381,7 @@ class Analysis1d(AnalysisBase):
         components: ComponentCollection | ModelComponent,
         convolver: Convolution | None = None,
         convolve: bool = True,
+        energy: sc.Variable | None = None,
     ) -> np.ndarray:
         """Calculate the contribution of a set of components, optionally
         convolving with the resolution.
@@ -359,19 +404,43 @@ class Analysis1d(AnalysisBase):
                 Convolution object will be created if convolve is True.
             convolve (bool): Whether to perform convolution with the
                 resolution. Default is True.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
+
+        Returns:
+            np.ndarray: The evaluated contribution of the components.
+
+        Raises:
+            UnitError: If the energy and energy offset have incompatible
+                units.
         """
 
         Q_index = self._require_Q_index()
-        energy = self.energy.values
+        if energy is None:
+            energy = self._masked_energy
+
         energy_offset = self.instrument_model.get_energy_offset_at_Q(Q_index)
+
+        if energy.unit != energy_offset.unit:
+            try:
+                energy_offset.convert_unit(energy.unit)
+            except Exception as e:
+                raise UnitError(
+                    f'Energy and energy offset must have compatible units. '
+                    f'Got {energy.unit} and {energy_offset.unit}.'
+                ) from e
+
+        energy_with_offset = energy.copy()
+        energy_with_offset.values -= energy_offset.value
 
         # If there are no components, return zero
         if isinstance(components, ComponentCollection) and components.is_empty:
-            return np.zeros_like(energy)
+            return np.zeros_like(energy.values)
 
         # No convolution
         if not convolve:
-            return components.evaluate(energy - energy_offset.value)
+            return components.evaluate(energy_with_offset)
 
         # If a convolver is provided, use it. This allows reusing the
         # same convolver for multiple evaluations during fitting for
@@ -386,7 +455,7 @@ class Analysis1d(AnalysisBase):
         # We don't create a convolver if the resolution is empty.
         resolution = self.instrument_model.resolution_model.get_component_collection(Q_index)
         if resolution.is_empty:
-            return components.evaluate(energy - energy_offset.value)
+            return components.evaluate(energy_with_offset)
 
         conv = Convolution(
             sample_components=components,
@@ -397,10 +466,15 @@ class Analysis1d(AnalysisBase):
         )
         return conv.convolution()
 
-    def _evaluate_sample(self) -> np.ndarray:
+    def _evaluate_sample(self, energy: sc.DataArray | None = None) -> np.ndarray:
         """Evaluate the sample contribution for a given Q index.
 
         Assumes that self._convolver is up to date.
+
+        Args:
+            energy (sc.DataArray | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             np.ndarray: The evaluated sample contribution.
@@ -411,17 +485,22 @@ class Analysis1d(AnalysisBase):
             components=components,
             convolver=self._convolver,
             convolve=True,
+            energy=energy,
         )
 
     def _evaluate_sample_component(
         self,
         component: ModelComponent,
+        energy: sc.Variable | None = None,
     ) -> np.ndarray:
         """Evaluate a single sample component for the chosen Q index.
 
         Args:
             component (ModelComponent): The sample component to
                 evaluate.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             np.ndarray: The evaluated sample component contribution.
@@ -430,10 +509,16 @@ class Analysis1d(AnalysisBase):
             components=component,
             convolver=None,
             convolve=True,
+            energy=energy,
         )
 
-    def _evaluate_background(self) -> np.ndarray:
+    def _evaluate_background(self, energy: sc.DataArray | None = None) -> np.ndarray:
         """Evaluate the background contribution for the chosen Q index.
+
+        Args:
+            energy (sc.DataArray | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             np.ndarray: The evaluated background contribution.
@@ -446,11 +531,13 @@ class Analysis1d(AnalysisBase):
             components=background_components,
             convolver=None,
             convolve=False,
+            energy=energy,
         )
 
     def _evaluate_background_component(
         self,
         component: ModelComponent,
+        energy: sc.Variable | None = None,
     ) -> np.ndarray:
         """Evaluate a single background component for the chosen Q
         index.
@@ -458,6 +545,9 @@ class Analysis1d(AnalysisBase):
         Args:
             component (ModelComponent): The background component to
                 evaluate.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             np.ndarray: The evaluated background component contribution.
@@ -467,18 +557,30 @@ class Analysis1d(AnalysisBase):
             components=component,
             convolver=None,
             convolve=False,
+            energy=energy,
         )
 
-    def _create_convolver(self) -> Convolution | None:
+    def _create_convolver(
+        self,
+        energy: sc.Variable | None = None,
+    ) -> Convolution | None:
         """Initialize and return a Convolution object for the chosen Q
         index. If the necessary components for convolution are not
         available, return None.
+
+        Args:
+            energy (sc.Variable | None): Optional energy grid to use for
+                convolution. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             Convolution | None: The initialized Convolution object or
                 None if not available.
         """
         Q_index = self._require_Q_index()
+
+        if energy is None:
+            energy = self._masked_energy
 
         sample_components = self.sample_model.get_component_collection(Q_index)
         if sample_components.is_empty:
@@ -489,7 +591,7 @@ class Analysis1d(AnalysisBase):
         )
         if resolution_components.is_empty:
             return None
-        energy = self.energy
+
         # TODO: allow convolution options to be set.
         convolver = Convolution(
             sample_components=sample_components,
@@ -508,6 +610,7 @@ class Analysis1d(AnalysisBase):
         self,
         component: ModelComponent,
         background: np.ndarray | None = None,
+        energy: sc.Variable | None = None,
     ) -> sc.DataArray:
         """Create a scipp DataArray for a single component. Adds the
         background if it is not None.
@@ -516,58 +619,76 @@ class Analysis1d(AnalysisBase):
             component (ModelComponent): The component to evaluate
             background (np.ndarray | None): Optional background to add
                 to the component.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             sc.DataArray: The model calculation of the component.
         """
 
-        values = self._evaluate_sample_component(component=component)
+        values = self._evaluate_sample_component(component=component, energy=energy)
         if background is not None:
             values += background
-        return self._to_scipp_array(values=values)
+        return self._to_scipp_array(values=values, energy=energy)
 
     def _create_background_component_scipp_array(
         self,
         component: ModelComponent,
+        energy: sc.Variable | None = None,
     ) -> sc.DataArray:
         """Create a scipp DataArray for a single background component.
 
         Args:
             component (ModelComponent): The component to evaluate.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             sc.DataArray: The model calculation of the component.
         """
 
-        values = self._evaluate_background_component(component=component)
-        return self._to_scipp_array(values=values)
+        values = self._evaluate_background_component(
+            component=component,
+            energy=energy,
+        )
+        return self._to_scipp_array(values=values, energy=energy)
 
-    def _create_sample_scipp_array(self) -> sc.DataArray:
+    def _create_sample_scipp_array(self, energy: sc.Variable | None = None) -> sc.DataArray:
         """Create a scipp DataArray for the full sample model including
         background.
+
+        Args:
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             sc.DataArray: The model calculation of the full sample
                 model.
         """
-        values = self._calculate()
-        return self._to_scipp_array(values=values)
+        values = self.calculate(energy=energy)
+        return self._to_scipp_array(values=values, energy=energy)
 
     def _create_components_dataset_single_Q(
         self,
         add_background: bool = True,
+        energy: sc.Variable | None = None,
     ) -> dict[str, sc.DataArray]:
         """Create sc.DataArrays for all sample and background
         components.
 
         Args:
             add_background (bool): Whether to add background components.
+            energy (sc.Variable | None): Optional energy grid to use for
+                evaluation. If None, the energy grid from the experiment
+                is used.
 
         Returns:
             dict[str, sc.DataArray]: A dictionary of component names to
                 their corresponding sc.DataArrays.
         """
-
         scipp_arrays = {}
         sample_components = self.sample_model.get_component_collection(
             Q_index=self.Q_index
@@ -576,18 +697,27 @@ class Analysis1d(AnalysisBase):
         background_components = self.instrument_model.background_model.get_component_collection(
             Q_index=self.Q_index
         ).components
-        background = self._evaluate_background() if add_background else None
+
+        if energy is None:
+            energy = self._masked_energy
+
+        background = self._evaluate_background(energy=energy) if add_background else None
+
         for component in sample_components:
             scipp_arrays[component.display_name] = self._create_component_scipp_array(
-                component=component, background=background
+                component=component, background=background, energy=energy
             )
         for component in background_components:
             scipp_arrays[component.display_name] = self._create_background_component_scipp_array(
-                component=component
+                component=component, energy=energy
             )
         return sc.Dataset(scipp_arrays)
 
-    def _to_scipp_array(self, values: np.ndarray) -> sc.DataArray:
+    def _to_scipp_array(
+        self,
+        values: np.ndarray,
+        energy: sc.Variable | None = None,
+    ) -> sc.DataArray:
         """Convert a numpy array of values to a sc.DataArray with the
         correct coordinates for energy and Q.
 
@@ -598,10 +728,12 @@ class Analysis1d(AnalysisBase):
             sc.DataArray: The converted sc.DataArray.
         """
 
+        if energy is None:
+            energy = self._masked_energy
         return sc.DataArray(
             data=sc.array(dims=['energy'], values=values),
             coords={
-                'energy': self.energy,
+                'energy': energy,
                 'Q': self.Q[self.Q_index],
             },
         )

--- a/src/easydynamics/analysis/analysis1d.py
+++ b/src/easydynamics/analysis/analysis1d.py
@@ -490,13 +490,13 @@ class Analysis1d(AnalysisBase):
         )
         return conv.convolution()
 
-    def _evaluate_sample(self, energy: sc.DataArray | None = None) -> np.ndarray:
+    def _evaluate_sample(self, energy: sc.Variable | None = None) -> np.ndarray:
         """Evaluate the sample contribution for a given Q index.
 
         Assumes that self._convolver is up to date.
 
         Args:
-            energy (sc.DataArray | None): Optional energy grid to use for
+            energy (sc.Variable | None): Optional energy grid to use for
                 evaluation. If None, the energy grid from the experiment
                 is used.
 
@@ -536,11 +536,11 @@ class Analysis1d(AnalysisBase):
             energy=energy,
         )
 
-    def _evaluate_background(self, energy: sc.DataArray | None = None) -> np.ndarray:
+    def _evaluate_background(self, energy: sc.Variable | None = None) -> np.ndarray:
         """Evaluate the background contribution for the chosen Q index.
 
         Args:
-            energy (sc.DataArray | None): Optional energy grid to use for
+            energy (sc.Variable | None): Optional energy grid to use for
                 evaluation. If None, the energy grid from the experiment
                 is used.
 

--- a/src/easydynamics/convolution/convolution_base.py
+++ b/src/easydynamics/convolution/convolution_base.py
@@ -74,7 +74,7 @@ class ConvolutionBase:
             energy = np.array([float(energy)])
 
         if not isinstance(energy, (np.ndarray, sc.Variable)):
-            raise TypeError('Energy must be a numpy ndarray or a scipp Variable.')
+            raise TypeError(f'Energy must be a numpy ndarray or a scipp Variable. Got {energy}')
 
         if not isinstance(energy_unit, (str, sc.Unit)):
             raise TypeError('Energy_unit must be a string or sc.Unit.')

--- a/src/easydynamics/experiment/experiment.py
+++ b/src/easydynamics/experiment/experiment.py
@@ -187,8 +187,12 @@ class Experiment(NewBase):
         raise AttributeError('energy is a read-only property derived from the data.')
 
     def get_masked_energy(self, Q_index: int) -> sc.Variable | None:
-        """Get the energy values from the dataset, applying the mask if
-        present.
+        """Get the energy values from the dataset, removing points where
+        the y values or variances are NaN or Inf for the given Q index.
+
+        Args:
+            Q_index (int): The Q index to get the masked energy values
+                for.
 
         Returns:
             sc.Variable | None: The masked energy values from the

--- a/src/easydynamics/experiment/experiment.py
+++ b/src/easydynamics/experiment/experiment.py
@@ -38,7 +38,7 @@ class Experiment(NewBase):
 
     def __init__(
         self,
-        display_name: str = 'MyExperiment',
+        display_name: str = "MyExperiment",
         unique_name: str | None = None,
         data: sc.DataArray | str | None = None,
     ):
@@ -71,7 +71,7 @@ class Experiment(NewBase):
             self._data = data
         else:
             raise TypeError(
-                f'Data must be a sc.DataArray or a filename string, not {type(data).__name__}'
+                f"Data must be a sc.DataArray or a filename string, not {type(data).__name__}"
             )
 
         self._binned_data = (
@@ -105,7 +105,7 @@ class Experiment(NewBase):
             ValueError: If the dataset is missing required coordinates.
         """
         if not isinstance(value, sc.DataArray):
-            raise TypeError(f'Data must be a sc.DataArray, not {type(value).__name__}')
+            raise TypeError(f"Data must be a sc.DataArray, not {type(value).__name__}")
         self._validate_coordinates(value)
         self._data = value
         self._binned_data = (
@@ -134,7 +134,9 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since binned_data is read-only.
         """
-        raise AttributeError('binned_data is a read-only property. Use rebin() to rebin the data')
+        raise AttributeError(
+            "binned_data is a read-only property. Use rebin() to rebin the data"
+        )
 
     @property
     def Q(self) -> sc.Variable | None:
@@ -146,7 +148,7 @@ class Experiment(NewBase):
         """
         if self._data is None:
             return None
-        return self._binned_data.coords['Q']
+        return self._binned_data.coords["Q"]
 
     @Q.setter
     def Q(self, value: sc.Variable) -> None:
@@ -159,7 +161,7 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since Q is read-only.
         """
-        raise AttributeError('Q is a read-only property derived from the data.')
+        raise AttributeError("Q is a read-only property derived from the data.")
 
     @property
     def energy(self) -> sc.Variable | None:
@@ -171,7 +173,7 @@ class Experiment(NewBase):
         """
         if self._data is None:
             return None
-        return self._binned_data.coords['energy']
+        return self._binned_data.coords["energy"]
 
     @energy.setter
     def energy(self, value: sc.Variable) -> None:
@@ -184,7 +186,7 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since energy is read-only.
         """
-        raise AttributeError('energy is a read-only property derived from the data.')
+        raise AttributeError("energy is a read-only property derived from the data.")
 
     def get_masked_energy(self, Q_index: int) -> sc.Variable | None:
         """Get the energy values from the dataset, applying the mask if
@@ -194,21 +196,20 @@ class Experiment(NewBase):
             sc.Variable | None: The masked energy values from the
                 dataset, or None if no data is loaded.
         """
+        if self._data is None:
+            return None
 
         if (
             not isinstance(Q_index, int)
             or Q_index < 0
             or (self.Q is not None and Q_index >= len(self.Q))
         ):
-            raise IndexError('Q_index must be a valid index for the Q values.')
+            raise IndexError("Q_index must be a valid index for the Q values.")
 
-        if self._data is None:
-            return None
-
-        energy = self._binned_data.coords['energy']
+        energy = self._binned_data.coords["energy"]
         _, _, _, mask = self._extract_x_y_weights_only_finite(Q_index=Q_index)
 
-        mask_var = sc.array(dims=['energy'], values=mask)
+        mask_var = sc.array(dims=["energy"], values=mask)
         masked_energy = energy[mask_var]
         return masked_energy
 
@@ -231,19 +232,19 @@ class Experiment(NewBase):
                 coordinates.
         """
         if not isinstance(filename, str):
-            raise TypeError(f'Filename must be a string, not {type(filename).__name__}')
+            raise TypeError(f"Filename must be a string, not {type(filename).__name__}")
 
         if display_name is not None:
             if not isinstance(display_name, str):
                 raise TypeError(
-                    f'Display name must be a string, not {type(display_name).__name__}'
+                    f"Display name must be a string, not {type(display_name).__name__}"
                 )
             self.display_name = display_name
 
         loaded_data = sc_load_hdf5(filename)
         if not isinstance(loaded_data, sc.DataArray):
             raise TypeError(
-                f'Loaded data must be a sc.DataArray, not {type(loaded_data).__name__}'
+                f"Loaded data must be a sc.DataArray, not {type(loaded_data).__name__}"
             )
         self._validate_coordinates(loaded_data)
         self.data = loaded_data
@@ -262,13 +263,13 @@ class Experiment(NewBase):
         """
 
         if filename is None:
-            filename = f'{self.unique_name}.h5'
+            filename = f"{self.unique_name}.h5"
 
         if not isinstance(filename, str):
-            raise TypeError(f'Filename must be a string, not {type(filename).__name__}')
+            raise TypeError(f"Filename must be a string, not {type(filename).__name__}")
 
         if self._data is None:
-            raise ValueError('No data to save.')
+            raise ValueError("No data to save.")
 
         dir_name = os.path.dirname(filename)
         if dir_name:
@@ -297,31 +298,33 @@ class Experiment(NewBase):
 
         if not isinstance(dimensions, dict):
             raise TypeError(
-                'dimensions must be a dictionary mapping dimension names '
-                'to number of bins or bin values as sc.Variable.'
+                "dimensions must be a dictionary mapping dimension names "
+                "to number of bins or bin values as sc.Variable."
             )
         if self._data is None:
-            raise ValueError('No data to rebin. Please load data first.')
+            raise ValueError("No data to rebin. Please load data first.")
         binned_data = self._data.copy()
         dim_copy = dimensions.copy()
         for dim, value in dim_copy.items():
             if not isinstance(dim, str):
                 raise TypeError(
-                    f'Dimension keys must be strings. Got {type(dim)} for {dim} instead.'
+                    f"Dimension keys must be strings. Got {type(dim)} for {dim} instead."
                 )
             if dim not in self._data.dims:
                 raise KeyError(
                     f"Dimension '{dim}' not a valid dimension for rebinning. "
-                    f'Should be one of {self._data.dims}.'
+                    f"Should be one of {self._data.dims}."
                 )
-            if isinstance(value, float) and value.is_integer():  # I allow eg. 2.0 as well as 2
+            if (
+                isinstance(value, float) and value.is_integer()
+            ):  # I allow eg. 2.0 as well as 2
                 value = int(value)
                 # This line can be removed when scipp resize support
                 # resizing with coordinates
                 dimensions[dim] = value
             if not (isinstance(value, int) or isinstance(value, sc.Variable)):
                 raise TypeError(
-                    f'Dimension values must be integers or sc.Variable. '
+                    f"Dimension values must be integers or sc.Variable. "
                     f"Got {type(value)} for dimension '{dim}' instead."
                 )
             binned_data = binned_data.bin({dim: value})
@@ -347,13 +350,15 @@ class Experiment(NewBase):
         """
 
         if self._binned_data is None:
-            raise ValueError('No data to plot. Please load data first.')
+            raise ValueError("No data to plot. Please load data first.")
 
         if not _in_notebook():
-            raise RuntimeError('plot_data() can only be used in a Jupyter notebook environment.')
+            raise RuntimeError(
+                "plot_data() can only be used in a Jupyter notebook environment."
+            )
 
         plot_kwargs_defaults = {
-            'title': self.display_name,
+            "title": self.display_name,
         }
         # Overwrite defaults with any user-provided kwargs
         plot_kwargs_defaults.update(kwargs)
@@ -364,7 +369,7 @@ class Experiment(NewBase):
             )
         else:
             fig = pp.plot(
-                self._binned_data.transpose(dims=['energy', 'Q']),
+                self._binned_data.transpose(dims=["energy", "Q"]),
                 **plot_kwargs_defaults,
             )
         return fig
@@ -384,9 +389,9 @@ class Experiment(NewBase):
             ValueError: If required coordinates are missing.
         """
         if not isinstance(data, sc.DataArray):
-            raise TypeError('Data must be a sc.DataArray.')
+            raise TypeError("Data must be a sc.DataArray.")
 
-        required_coords = ['Q', 'energy']
+        required_coords = ["Q", "energy"]
         for coord in required_coords:
             if coord not in data.coords:
                 raise ValueError(f"Data is missing required coordinate: '{coord}'")
@@ -419,8 +424,8 @@ class Experiment(NewBase):
                 weights arrays extracted from the experiment for the
                 given Q index.
         """
-        data = self.binned_data['Q', Q_index]
-        x = data.coords['energy'].values
+        data = self.binned_data["Q", Q_index]
+        x = data.coords["energy"].values
         y = data.values
         e = data.variances**0.5
         return x, y, e
@@ -452,7 +457,7 @@ class Experiment(NewBase):
         e = e[mask]
 
         if np.any(e == 0):
-            raise ValueError('Cannot compute weights: some variances are zero.')
+            raise ValueError("Cannot compute weights: some variances are zero.")
         weights = 1.0 / e
 
         return x, y, weights, mask
@@ -468,15 +473,15 @@ class Experiment(NewBase):
             str: A string representation of the Experiment object.
         """
 
-        return f'Experiment `{self.unique_name}` with data: {self._data}'
+        return f"Experiment `{self.unique_name}` with data: {self._data}"
 
-    def __copy__(self) -> 'Experiment':
+    def __copy__(self) -> "Experiment":
         """Return a copy of the object.
 
         Returns:
             Experiment: A copy of the Experiment object.
         """
-        temp = self.to_dict(skip=['unique_name'])
+        temp = self.to_dict(skip=["unique_name"])
         new_obj = self.__class__.from_dict(temp)
         new_obj.data = self.data.copy() if self.data is not None else None
         return new_obj

--- a/src/easydynamics/experiment/experiment.py
+++ b/src/easydynamics/experiment/experiment.py
@@ -38,7 +38,7 @@ class Experiment(NewBase):
 
     def __init__(
         self,
-        display_name: str = "MyExperiment",
+        display_name: str = 'MyExperiment',
         unique_name: str | None = None,
         data: sc.DataArray | str | None = None,
     ):
@@ -71,7 +71,7 @@ class Experiment(NewBase):
             self._data = data
         else:
             raise TypeError(
-                f"Data must be a sc.DataArray or a filename string, not {type(data).__name__}"
+                f'Data must be a sc.DataArray or a filename string, not {type(data).__name__}'
             )
 
         self._binned_data = (
@@ -105,7 +105,7 @@ class Experiment(NewBase):
             ValueError: If the dataset is missing required coordinates.
         """
         if not isinstance(value, sc.DataArray):
-            raise TypeError(f"Data must be a sc.DataArray, not {type(value).__name__}")
+            raise TypeError(f'Data must be a sc.DataArray, not {type(value).__name__}')
         self._validate_coordinates(value)
         self._data = value
         self._binned_data = (
@@ -134,9 +134,7 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since binned_data is read-only.
         """
-        raise AttributeError(
-            "binned_data is a read-only property. Use rebin() to rebin the data"
-        )
+        raise AttributeError('binned_data is a read-only property. Use rebin() to rebin the data')
 
     @property
     def Q(self) -> sc.Variable | None:
@@ -146,9 +144,9 @@ class Experiment(NewBase):
             sc.Variable | None: The Q values from the dataset, or None
                 if no data is loaded.
         """
-        if self._data is None:
+        if self._binned_data is None:
             return None
-        return self._binned_data.coords["Q"]
+        return self._binned_data.coords['Q']
 
     @Q.setter
     def Q(self, value: sc.Variable) -> None:
@@ -161,7 +159,7 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since Q is read-only.
         """
-        raise AttributeError("Q is a read-only property derived from the data.")
+        raise AttributeError('Q is a read-only property derived from the data.')
 
     @property
     def energy(self) -> sc.Variable | None:
@@ -171,9 +169,9 @@ class Experiment(NewBase):
             sc.Variable | None: The energy values from the dataset, or
                 None if no data is loaded.
         """
-        if self._data is None:
+        if self._binned_data is None:
             return None
-        return self._binned_data.coords["energy"]
+        return self._binned_data.coords['energy']
 
     @energy.setter
     def energy(self, value: sc.Variable) -> None:
@@ -186,7 +184,7 @@ class Experiment(NewBase):
         Raises:
             AttributeError: Always, since energy is read-only.
         """
-        raise AttributeError("energy is a read-only property derived from the data.")
+        raise AttributeError('energy is a read-only property derived from the data.')
 
     def get_masked_energy(self, Q_index: int) -> sc.Variable | None:
         """Get the energy values from the dataset, applying the mask if
@@ -196,7 +194,7 @@ class Experiment(NewBase):
             sc.Variable | None: The masked energy values from the
                 dataset, or None if no data is loaded.
         """
-        if self._data is None:
+        if self._binned_data is None:
             return None
 
         if (
@@ -204,12 +202,12 @@ class Experiment(NewBase):
             or Q_index < 0
             or (self.Q is not None and Q_index >= len(self.Q))
         ):
-            raise IndexError("Q_index must be a valid index for the Q values.")
+            raise IndexError('Q_index must be a valid index for the Q values.')
 
-        energy = self._binned_data.coords["energy"]
+        energy = self._binned_data.coords['energy']
         _, _, _, mask = self._extract_x_y_weights_only_finite(Q_index=Q_index)
 
-        mask_var = sc.array(dims=["energy"], values=mask)
+        mask_var = sc.array(dims=['energy'], values=mask)
         masked_energy = energy[mask_var]
         return masked_energy
 
@@ -232,19 +230,19 @@ class Experiment(NewBase):
                 coordinates.
         """
         if not isinstance(filename, str):
-            raise TypeError(f"Filename must be a string, not {type(filename).__name__}")
+            raise TypeError(f'Filename must be a string, not {type(filename).__name__}')
 
         if display_name is not None:
             if not isinstance(display_name, str):
                 raise TypeError(
-                    f"Display name must be a string, not {type(display_name).__name__}"
+                    f'Display name must be a string, not {type(display_name).__name__}'
                 )
             self.display_name = display_name
 
         loaded_data = sc_load_hdf5(filename)
         if not isinstance(loaded_data, sc.DataArray):
             raise TypeError(
-                f"Loaded data must be a sc.DataArray, not {type(loaded_data).__name__}"
+                f'Loaded data must be a sc.DataArray, not {type(loaded_data).__name__}'
             )
         self._validate_coordinates(loaded_data)
         self.data = loaded_data
@@ -263,13 +261,13 @@ class Experiment(NewBase):
         """
 
         if filename is None:
-            filename = f"{self.unique_name}.h5"
+            filename = f'{self.unique_name}.h5'
 
         if not isinstance(filename, str):
-            raise TypeError(f"Filename must be a string, not {type(filename).__name__}")
+            raise TypeError(f'Filename must be a string, not {type(filename).__name__}')
 
         if self._data is None:
-            raise ValueError("No data to save.")
+            raise ValueError('No data to save.')
 
         dir_name = os.path.dirname(filename)
         if dir_name:
@@ -298,33 +296,31 @@ class Experiment(NewBase):
 
         if not isinstance(dimensions, dict):
             raise TypeError(
-                "dimensions must be a dictionary mapping dimension names "
-                "to number of bins or bin values as sc.Variable."
+                'dimensions must be a dictionary mapping dimension names '
+                'to number of bins or bin values as sc.Variable.'
             )
         if self._data is None:
-            raise ValueError("No data to rebin. Please load data first.")
+            raise ValueError('No data to rebin. Please load data first.')
         binned_data = self._data.copy()
         dim_copy = dimensions.copy()
         for dim, value in dim_copy.items():
             if not isinstance(dim, str):
                 raise TypeError(
-                    f"Dimension keys must be strings. Got {type(dim)} for {dim} instead."
+                    f'Dimension keys must be strings. Got {type(dim)} for {dim} instead.'
                 )
             if dim not in self._data.dims:
                 raise KeyError(
                     f"Dimension '{dim}' not a valid dimension for rebinning. "
-                    f"Should be one of {self._data.dims}."
+                    f'Should be one of {self._data.dims}.'
                 )
-            if (
-                isinstance(value, float) and value.is_integer()
-            ):  # I allow eg. 2.0 as well as 2
+            if isinstance(value, float) and value.is_integer():  # I allow eg. 2.0 as well as 2
                 value = int(value)
                 # This line can be removed when scipp resize support
                 # resizing with coordinates
                 dimensions[dim] = value
             if not (isinstance(value, int) or isinstance(value, sc.Variable)):
                 raise TypeError(
-                    f"Dimension values must be integers or sc.Variable. "
+                    f'Dimension values must be integers or sc.Variable. '
                     f"Got {type(value)} for dimension '{dim}' instead."
                 )
             binned_data = binned_data.bin({dim: value})
@@ -350,15 +346,13 @@ class Experiment(NewBase):
         """
 
         if self._binned_data is None:
-            raise ValueError("No data to plot. Please load data first.")
+            raise ValueError('No data to plot. Please load data first.')
 
         if not _in_notebook():
-            raise RuntimeError(
-                "plot_data() can only be used in a Jupyter notebook environment."
-            )
+            raise RuntimeError('plot_data() can only be used in a Jupyter notebook environment.')
 
         plot_kwargs_defaults = {
-            "title": self.display_name,
+            'title': self.display_name,
         }
         # Overwrite defaults with any user-provided kwargs
         plot_kwargs_defaults.update(kwargs)
@@ -369,7 +363,7 @@ class Experiment(NewBase):
             )
         else:
             fig = pp.plot(
-                self._binned_data.transpose(dims=["energy", "Q"]),
+                self._binned_data.transpose(dims=['energy', 'Q']),
                 **plot_kwargs_defaults,
             )
         return fig
@@ -389,9 +383,9 @@ class Experiment(NewBase):
             ValueError: If required coordinates are missing.
         """
         if not isinstance(data, sc.DataArray):
-            raise TypeError("Data must be a sc.DataArray.")
+            raise TypeError('Data must be a sc.DataArray.')
 
-        required_coords = ["Q", "energy"]
+        required_coords = ['Q', 'energy']
         for coord in required_coords:
             if coord not in data.coords:
                 raise ValueError(f"Data is missing required coordinate: '{coord}'")
@@ -412,7 +406,7 @@ class Experiment(NewBase):
                 data = data.assign_coords({dim: sc.midpoints(coord)})
         return data
 
-    def _extract_x_y_e(self, Q_index: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def _extract_x_y_var(self, Q_index: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Extract the x, y, and weights arrays from the experiment for
         the given Q index.
 
@@ -421,14 +415,14 @@ class Experiment(NewBase):
 
         Returns:
             tuple[np.ndarray, np.ndarray, np.ndarray]: The x, y, and
-                weights arrays extracted from the experiment for the
+                variances arrays extracted from the experiment for the
                 given Q index.
         """
-        data = self.binned_data["Q", Q_index]
-        x = data.coords["energy"].values
+        data = self.binned_data['Q', Q_index]
+        x = data.coords['energy'].values
         y = data.values
-        e = data.variances**0.5
-        return x, y, e
+        var = data.variances
+        return x, y, var
 
     def _extract_x_y_weights_only_finite(
         self, Q_index: int
@@ -449,16 +443,24 @@ class Experiment(NewBase):
             ValueError: If any variances are zero after removing NaNs
                 and Infs, since this would lead to infinite weights.
         """
-        x, y, e = self._extract_x_y_e(Q_index)
-        mask = np.isfinite(y) & np.isfinite(e) & np.isfinite(x)
+        x, y, var = self._extract_x_y_var(Q_index)
+
+        if var is None:
+            mask = np.isfinite(y) & np.isfinite(x)
+            # If variances are not provided, set them to 1 to make all
+            # weights be 1
+            var = np.ones_like(y)
+        else:
+            mask = np.isfinite(y) & np.isfinite(var) & np.isfinite(x)
 
         x = x[mask]
         y = y[mask]
-        e = e[mask]
+        var = var[mask]
 
-        if np.any(e == 0):
-            raise ValueError("Cannot compute weights: some variances are zero.")
-        weights = 1.0 / e
+        if np.any(var == 0):
+            raise ValueError('Cannot compute weights: some variances are zero.')
+
+        weights = 1.0 / var**0.5
 
         return x, y, weights, mask
 
@@ -473,15 +475,15 @@ class Experiment(NewBase):
             str: A string representation of the Experiment object.
         """
 
-        return f"Experiment `{self.unique_name}` with data: {self._data}"
+        return f'Experiment `{self.unique_name}` with data: {self._data}'
 
-    def __copy__(self) -> "Experiment":
+    def __copy__(self) -> 'Experiment':
         """Return a copy of the object.
 
         Returns:
             Experiment: A copy of the Experiment object.
         """
-        temp = self.to_dict(skip=["unique_name"])
+        temp = self.to_dict(skip=['unique_name'])
         new_obj = self.__class__.from_dict(temp)
         new_obj.data = self.data.copy() if self.data is not None else None
         return new_obj

--- a/src/easydynamics/experiment/experiment.py
+++ b/src/easydynamics/experiment/experiment.py
@@ -186,6 +186,32 @@ class Experiment(NewBase):
         """
         raise AttributeError('energy is a read-only property derived from the data.')
 
+    def get_masked_energy(self, Q_index: int) -> sc.Variable | None:
+        """Get the energy values from the dataset, applying the mask if
+        present.
+
+        Returns:
+            sc.Variable | None: The masked energy values from the
+                dataset, or None if no data is loaded.
+        """
+
+        if (
+            not isinstance(Q_index, int)
+            or Q_index < 0
+            or (self.Q is not None and Q_index >= len(self.Q))
+        ):
+            raise IndexError('Q_index must be a valid index for the Q values.')
+
+        if self._data is None:
+            return None
+
+        energy = self._binned_data.coords['energy']
+        _, _, _, mask = self._extract_x_y_weights_only_finite(Q_index=Q_index)
+
+        mask_var = sc.array(dims=['energy'], values=mask)
+        masked_energy = energy[mask_var]
+        return masked_energy
+
     ###########
     # Handle data
     ###########
@@ -393,7 +419,7 @@ class Experiment(NewBase):
                 weights arrays extracted from the experiment for the
                 given Q index.
         """
-        data = self.data['Q', Q_index]
+        data = self.binned_data['Q', Q_index]
         x = data.coords['energy'].values
         y = data.values
         e = data.variances**0.5
@@ -401,7 +427,7 @@ class Experiment(NewBase):
 
     def _extract_x_y_weights_only_finite(
         self, Q_index: int
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Extract the x, y, and weights arrays from the experiment for
         the given Q index, removing any NaN and Inf values.
 
@@ -409,9 +435,10 @@ class Experiment(NewBase):
             Q_index (int): The Q index to extract the data for.
 
         Returns:
-            tuple[np.ndarray, np.ndarray, np.ndarray]: The x, y, and
-                weights arrays extracted from the experiment for the
-                given Q index, with NaNs and Infs removed.
+            tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]: The
+                x, y, weights, and mask arrays extracted from the
+                experiment for the given Q index, with NaNs and Infs
+                removed.
 
         Raises:
             ValueError: If any variances are zero after removing NaNs
@@ -428,7 +455,7 @@ class Experiment(NewBase):
             raise ValueError('Cannot compute weights: some variances are zero.')
         weights = 1.0 / e
 
-        return x, y, weights
+        return x, y, weights, mask
 
     ########
     # dunder methods

--- a/tests/unit/easydynamics/analysis/test_analysis.py
+++ b/tests/unit/easydynamics/analysis/test_analysis.py
@@ -193,7 +193,7 @@ class TestAnalysis:
 
         # EXPECT
         analysis.analysis_list[1].plot_data_and_model.assert_called_once_with(
-            plot_components=True, add_background=True, **kwargs
+            plot_components=True, add_background=True, energy=None, **kwargs
         )
         assert result == 'plot_Q1'
 
@@ -279,6 +279,7 @@ class TestAnalysis:
         fake_fig = object()
 
         analysis._create_model_array = MagicMock(return_value='MODEL')
+        analysis._create_components_dataset = MagicMock(return_value={'Gaussian': 'GAUSS'})
         with (
             patch('plopp.slicer', return_value=fake_fig) as mock_slicer,
             patch.object(

--- a/tests/unit/easydynamics/analysis/test_analysis.py
+++ b/tests/unit/easydynamics/analysis/test_analysis.py
@@ -88,6 +88,22 @@ class TestAnalysis:
 
         # EXPECT
         analysis.analysis_list[1].calculate.assert_called_once()
+        _, kwargs = analysis.analysis_list[1].calculate.call_args
+        assert sc.identical(kwargs['energy'], analysis.energy)
+        np.testing.assert_array_equal(result, np.array([4.0, 5.0, 6.0]))
+
+    def test_calculate_with_Q_index_and_energy(self, analysis):
+        # WHEN
+        analysis.analysis_list[1].calculate = MagicMock(return_value=np.array([4.0, 5.0, 6.0]))
+        energy = sc.array(dims=['energy'], values=[20.0, 30.0, 40.0], unit='meV')
+
+        # THEN
+        result = analysis.calculate(Q_index=1, energy=energy)
+
+        # EXPECT
+        analysis.analysis_list[1].calculate.assert_called_once()
+        _, kwargs = analysis.analysis_list[1].calculate.call_args
+        assert kwargs['energy'] is energy
         np.testing.assert_array_equal(result, np.array([4.0, 5.0, 6.0]))
 
     def test_calculate_without_Q_index(self, analysis):

--- a/tests/unit/easydynamics/analysis/test_analysis1d.py
+++ b/tests/unit/easydynamics/analysis/test_analysis1d.py
@@ -303,6 +303,72 @@ class TestAnalysis1d:
         # EXPECT
         analysis1d._create_convolver.assert_called_once()
 
+    def test_verify_energy(self, analysis1d):
+        # WHEN
+        energy = sc.array(dims=['energy'], values=[10.0, 20.0, 30.0], unit='meV')
+
+        # THEN
+        result = analysis1d._verify_energy(energy)
+
+        # EXPECT
+        assert sc.identical(result, energy)
+
+    def test_verify_energy_None(self, analysis1d):
+        # WHEN
+        energy = None
+
+        # THEN
+        result = analysis1d._verify_energy(energy)
+
+        # EXPECT
+        assert result is None
+
+    def test_verify_energy_raises(self, analysis1d):
+        # WHEN
+        energy = np.array([10.0, 20.0])
+
+        # THEN / EXPECT
+        with pytest.raises(TypeError, match='Energy must be a sc.Variable or None'):
+            analysis1d._verify_energy(energy)
+
+    def test_calculate_energy_with_offset(self, analysis1d):
+        # WHEN
+        energy = analysis1d.experiment.energy
+        energy_offset = analysis1d.instrument_model.get_energy_offset_at_Q(analysis1d.Q_index)
+        energy_offset.value = 1.0  # override with a simple value for testing
+
+        # THEN
+        result = analysis1d._calculate_energy_with_offset(energy, energy_offset)
+
+        # EXPECT
+        expected = energy.values - energy_offset.value
+        np.testing.assert_array_equal(result.values, expected)
+
+    def test_calculate_energy_with_offset_different_units(self, analysis1d):
+        # WHEN
+        energy = analysis1d.experiment.energy
+        energy_offset = analysis1d.instrument_model.get_energy_offset_at_Q(analysis1d.Q_index)
+        energy_offset.value = 1.0  # override with a simple value for testing
+        energy_offset.convert_unit('eV')
+
+        # THEN
+        result = analysis1d._calculate_energy_with_offset(energy, energy_offset)
+
+        # EXPECT
+        expected = energy.values - energy_offset.value
+        np.testing.assert_array_equal(result.values, expected)
+
+    def test_calculate_energy_with_offset_raises_if_incompatible_units(self, analysis1d):
+        # WHEN
+        energy = analysis1d.experiment.energy
+        energy_offset = Parameter(name='energy_offset', value=1.0, unit='m')  # incompatible unit
+
+        # THEN / EXPECT
+        with pytest.raises(
+            sc.UnitError, match='Energy and energy offset must have compatible units'
+        ):
+            analysis1d._calculate_energy_with_offset(energy, energy_offset)
+
     #############
     # Private methods: evaluation
     #############

--- a/tests/unit/easydynamics/analysis/test_analysis1d.py
+++ b/tests/unit/easydynamics/analysis/test_analysis1d.py
@@ -150,9 +150,10 @@ class TestAnalysis1d:
         fake_x = np.array([1, 2, 3])
         fake_y = np.array([10, 20, 30])
         fake_weights = np.array([0.1, 0.2, 0.3])
+        fake_mask = np.array([True, False, True])
 
         analysis1d.experiment._extract_x_y_weights_only_finite = MagicMock(
-            return_value=(fake_x, fake_y, fake_weights)
+            return_value=(fake_x, fake_y, fake_weights, fake_mask)
         )
 
         analysis1d._create_convolver = MagicMock(return_value='fake_convolver')
@@ -397,10 +398,7 @@ class TestAnalysis1d:
 
             # check that the energy array passed to the convolver is the
             # same as the analysis1d energy array
-            np.testing.assert_array_equal(
-                kwargs['energy'],
-                analysis1d.energy.values,
-            )
+            assert sc.identical(kwargs['energy'], analysis1d.energy)
 
             # and check that convolution() was called
             MockConvolution.return_value.convolution.assert_called_once_with()
@@ -427,6 +425,7 @@ class TestAnalysis1d:
             components=analysis1d.sample_model.get_component_collection(),
             convolver=analysis1d._convolver,
             convolve=True,
+            energy=None,
         )
 
     def test_evaluate_sample_component(self, analysis1d):
@@ -445,6 +444,7 @@ class TestAnalysis1d:
             components=component,
             convolver=None,
             convolve=True,
+            energy=None,
         )
 
     def test_evaluate_background(self, analysis1d):
@@ -469,6 +469,7 @@ class TestAnalysis1d:
             components=analysis1d.instrument_model.background_model.get_component_collection(),
             convolver=None,
             convolve=False,
+            energy=None,
         )
 
     def test_evaluate_background_component(self, analysis1d):
@@ -487,6 +488,7 @@ class TestAnalysis1d:
             components=component,
             convolver=None,
             convolve=False,
+            energy=None,
         )
 
     def test_create_convolver(self, analysis1d):
@@ -582,7 +584,9 @@ class TestAnalysis1d:
         analysis1d._create_component_scipp_array(component=component, background=background)
 
         # EXPECT
-        analysis1d._evaluate_sample_component.assert_called_once_with(component=component)
+        analysis1d._evaluate_sample_component.assert_called_once_with(
+            component=component, energy=None
+        )
 
         expected_values = np.array([1.0, 2.0, 3.0])
         if background is not None:
@@ -617,7 +621,10 @@ class TestAnalysis1d:
         analysis1d._create_background_component_scipp_array(component=component)
 
         # EXPECT
-        analysis1d._evaluate_background_component.assert_called_once_with(component=component)
+        analysis1d._evaluate_background_component.assert_called_once_with(
+            component=component,
+            energy=None,
+        )
 
         analysis1d._to_scipp_array.assert_called_once()
 
@@ -699,7 +706,7 @@ class TestAnalysis1d:
         )
 
         # ---- Background evaluation ----
-        background_value = np.array([10.0, 20.0, 30.0])
+        background_value = np.array([11.0, 21.0, 31.0])
         analysis1d._evaluate_background = MagicMock(return_value=background_value)
 
         # ---- Return scipp DataArrays ----
@@ -753,9 +760,10 @@ class TestAnalysis1d:
             )
 
         # Background component creation
-        analysis1d._create_background_component_scipp_array.assert_called_once_with(
-            component=background_component
-        )
+        analysis1d._create_background_component_scipp_array.assert_called_once()
+        _, kwargs = analysis1d._create_background_component_scipp_array.call_args
+        assert kwargs['component'] is background_component
+        assert sc.identical(kwargs['energy'], analysis1d.energy)
 
         # Dataset content
         assert isinstance(dataset, sc.Dataset)

--- a/tests/unit/easydynamics/experiment/test_experiment.py
+++ b/tests/unit/easydynamics/experiment/test_experiment.py
@@ -307,7 +307,7 @@ class TestExperiment:
         masked_energy = experiment_with_data.get_masked_energy(Q_index=Q_index)
 
         # EXPECT
-        len(masked_energy) == 1
+        assert len(masked_energy) == 1
         assert masked_energy.values == 30.0
 
     def test_get_masked_energy_no_data_returns_None(self):

--- a/tests/unit/easydynamics/experiment/test_experiment.py
+++ b/tests/unit/easydynamics/experiment/test_experiment.py
@@ -434,7 +434,7 @@ class TestExperiment:
         invalid_data.data.variances[Q_index][1] = np.nan
 
         # THEN
-        x, y, weights = Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
+        x, y, weights, mask = Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
             Q_index=Q_index
         )
 
@@ -444,6 +444,8 @@ class TestExperiment:
         assert np.isfinite(weights).all()
         assert weights[0] == 1.0 / (experiment_with_data.data.variances[Q_index][2] ** 0.5)
         assert len(x) == len(y) == len(weights) == 1  # 2 values should be removed
+        # Mask should indicate which values were removed
+        assert np.array_equal(mask, [False, False, True])
 
     ##############
     # test dunder methods

--- a/tests/unit/easydynamics/experiment/test_experiment.py
+++ b/tests/unit/easydynamics/experiment/test_experiment.py
@@ -15,26 +15,26 @@ from easydynamics.experiment import Experiment
 class TestExperiment:
     @pytest.fixture
     def experiment(self):
-        Q = sc.linspace('Q', 0.5, 1.5, num=10, unit='1/Angstrom')
-        energy = sc.linspace('energy', -5, 5, num=11, unit='meV')
-        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 11)))
-        data = sc.DataArray(data=values, coords={'Q': Q, 'energy': energy})
+        Q = sc.linspace("Q", 0.5, 1.5, num=10, unit="1/Angstrom")
+        energy = sc.linspace("energy", -5, 5, num=11, unit="meV")
+        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 11)))
+        data = sc.DataArray(data=values, coords={"Q": Q, "energy": energy})
 
-        experiment = Experiment(display_name='test_experiment', data=data)
+        experiment = Experiment(display_name="test_experiment", data=data)
         return experiment
 
     @pytest.fixture
     def experiment_with_data(self):
         "Fixture that provides an Experiment with data for testing methods that require data"
-        Q = sc.array(dims=['Q'], values=[1, 2, 3], unit='1/Angstrom')
-        energy = sc.array(dims=['energy'], values=[10.0, 20.0, 30.0], unit='meV')
+        Q = sc.array(dims=["Q"], values=[1, 2, 3], unit="1/Angstrom")
+        energy = sc.array(dims=["energy"], values=[10.0, 20.0, 30.0], unit="meV")
         data = sc.array(
-            dims=['Q', 'energy'],
+            dims=["Q", "energy"],
             values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
             variances=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
         )
 
-        data_array = sc.DataArray(data=data, coords={'Q': Q, 'energy': energy})
+        data_array = sc.DataArray(data=data, coords={"Q": Q, "energy": energy})
 
         experiment = Experiment(data=data_array)
 
@@ -47,51 +47,51 @@ class TestExperiment:
     def test_init_array(self, experiment):
         "Test initialization with a Scipp DataArray"
         # WHEN THEN EXPECT
-        assert experiment.display_name == 'test_experiment'
+        assert experiment.display_name == "test_experiment"
         assert isinstance(experiment._data, sc.DataArray)
-        assert 'Q' in experiment._data.dims
-        assert 'energy' in experiment._data.dims
-        assert experiment._data.sizes['Q'] == 10
-        assert experiment._data.sizes['energy'] == 11
+        assert "Q" in experiment._data.dims
+        assert "energy" in experiment._data.dims
+        assert experiment._data.sizes["Q"] == 10
+        assert experiment._data.sizes["energy"] == 11
         assert sc.identical(
             experiment._data.data,
-            sc.array(dims=['Q', 'energy'], values=np.ones((10, 11))),
+            sc.array(dims=["Q", "energy"], values=np.ones((10, 11))),
         )
 
     def test_init_string(self, tmp_path):
         "Test initialization with a filename string,"
-        'should load the file'
+        "should load the file"
         # WHEN
-        Q = sc.linspace('Q', 0.5, 1.5, num=10, unit='1/Angstrom')
-        energy = sc.linspace('energy', -5, 5, num=11, unit='meV')
-        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 11)))
-        data = sc.DataArray(data=values, coords={'Q': Q, 'energy': energy})
+        Q = sc.linspace("Q", 0.5, 1.5, num=10, unit="1/Angstrom")
+        energy = sc.linspace("energy", -5, 5, num=11, unit="meV")
+        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 11)))
+        data = sc.DataArray(data=values, coords={"Q": Q, "energy": energy})
 
-        filename = tmp_path / 'test_experiment.h5'
+        filename = tmp_path / "test_experiment.h5"
         sc.io.save_hdf5(data, filename)
 
         # THEN
-        experiment = Experiment(display_name='loaded_experiment', data=str(filename))
+        experiment = Experiment(display_name="loaded_experiment", data=str(filename))
 
         # EXPECT
-        assert experiment.display_name == 'loaded_experiment'
+        assert experiment.display_name == "loaded_experiment"
         assert isinstance(experiment._data, sc.DataArray)
-        assert 'Q' in experiment._data.dims
-        assert 'energy' in experiment._data.dims
-        assert experiment._data.sizes['Q'] == 10
-        assert experiment._data.sizes['energy'] == 11
+        assert "Q" in experiment._data.dims
+        assert "energy" in experiment._data.dims
+        assert experiment._data.sizes["Q"] == 10
+        assert experiment._data.sizes["energy"] == 11
         assert sc.identical(
             experiment._data.data,
-            sc.array(dims=['Q', 'energy'], values=np.ones((10, 11))),
+            sc.array(dims=["Q", "energy"], values=np.ones((10, 11))),
         )
 
     def test_init_no_data(self):
         "Test initialization with no data"
         # WHEN
-        experiment = Experiment(display_name='empty_experiment')
+        experiment = Experiment(display_name="empty_experiment")
 
         # THEN EXPECT
-        assert experiment.display_name == 'empty_experiment'
+        assert experiment.display_name == "empty_experiment"
         assert experiment._data is None
         assert experiment.energy is None
         assert experiment.Q is None
@@ -108,34 +108,34 @@ class TestExperiment:
 
     def test_load_hdf5(self, tmp_path, experiment):
         "Test loading data from an HDF5 file."
-        'First use scipp to save data to a file, '
-        'then load it using the method.'
+        "First use scipp to save data to a file, "
+        "then load it using the method."
         # WHEN
         # First create a file to load from
-        filename = tmp_path / 'test.h5'
+        filename = tmp_path / "test.h5"
         data_to_save = experiment.data
         sc.io.save_hdf5(data_to_save, filename)
 
         # THEN
-        new_experiment = Experiment(display_name='new_experiment')
-        new_experiment.load_hdf5(str(filename), display_name='loaded_data')
+        new_experiment = Experiment(display_name="new_experiment")
+        new_experiment.load_hdf5(str(filename), display_name="loaded_data")
         loaded_data = new_experiment.data
 
         # EXPECT
         assert sc.identical(data_to_save, loaded_data)
-        assert new_experiment.display_name == 'loaded_data'
+        assert new_experiment.display_name == "loaded_data"
 
     def test_load_hdf5_invalid_name_raises(self, experiment):
         "Test loading data from an HDF5 file,"
-        'giving the Experiment an invalid name'
+        "giving the Experiment an invalid name"
         # WHEN / THEN EXPECT
         with pytest.raises(TypeError):
-            experiment.load_hdf5('some_file.h5', display_name=123)
+            experiment.load_hdf5("some_file.h5", display_name=123)
 
     def test_load_hdf5_invalid_filename_raises(self, experiment):
         "Test loading data from an HDF5 file with an invalid filename"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match='must be a string'):
+        with pytest.raises(TypeError, match="must be a string"):
             experiment.load_hdf5(123)
 
     def test_load_hdf5_invalid_file_raises(self, experiment):
@@ -143,13 +143,13 @@ class TestExperiment:
         # WHEN / THEN EXPECT
 
         with pytest.raises(OSError):
-            experiment.load_hdf5('non_existent_file.h5')
+            experiment.load_hdf5("non_existent_file.h5")
 
     def test_save_hdf5(self, tmp_path, experiment):
         "Test saving data to an HDF5 file. Load the saved file"
-        'using scipp and compare to the original data.'
+        "using scipp and compare to the original data."
         # WHEN THEN
-        filename = tmp_path / 'saved_data.h5'
+        filename = tmp_path / "saved_data.h5"
         experiment.save_hdf5(str(filename))
 
         # EXPECT
@@ -166,25 +166,25 @@ class TestExperiment:
         experiment.save_hdf5()
 
         # EXPECT
-        expected_filename = tmp_path / f'{experiment.unique_name}.h5'
+        expected_filename = tmp_path / f"{experiment.unique_name}.h5"
         loaded_data = sc.io.load_hdf5(str(expected_filename))
         original_data = experiment.data
         assert sc.identical(original_data, loaded_data)
 
     def test_save_hdf5_no_data_raises(self):
         "Test saving data to an HDF5 file when no data is present"
-        'in the experiment'
+        "in the experiment"
         # WHEN
         experiment = Experiment()
 
         # THEN EXPECT
         with pytest.raises(ValueError):
-            experiment.save_hdf5('should_fail.h5')
+            experiment.save_hdf5("should_fail.h5")
 
     def test_save_hdf5_invalid_filename_raises(self, experiment):
         "Test saving data to an HDF5 file with an invalid filename"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match='must be a string'):
+        with pytest.raises(TypeError, match="must be a string"):
             experiment.save_hdf5(123)
 
     def test_remove_data(self, experiment):
@@ -196,11 +196,11 @@ class TestExperiment:
         assert experiment._data is None
 
     @pytest.mark.parametrize(
-        'new_Q_bins, new_energy_bins',
+        "new_Q_bins, new_energy_bins",
         [
             (
-                sc.linspace('Q', 0.5, 1.5, num=7, unit='1/Angstrom'),
-                sc.linspace('energy', -5, 5, num=8, unit='meV'),
+                sc.linspace("Q", 0.5, 1.5, num=7, unit="1/Angstrom"),
+                sc.linspace("energy", -5, 5, num=8, unit="meV"),
             ),
             (
                 6,
@@ -211,23 +211,23 @@ class TestExperiment:
                 7.0,
             ),
             (
-                sc.linspace('Q', 0.5, 1.5, num=7, unit='1/Angstrom'),
+                sc.linspace("Q", 0.5, 1.5, num=7, unit="1/Angstrom"),
                 7,
             ),
         ],
-        ids=['sc_bins', 'integers_bins', 'float_bins', 'mixed_bins'],
+        ids=["sc_bins", "integers_bins", "float_bins", "mixed_bins"],
     )
     def test_rebin(self, experiment, new_Q_bins, new_energy_bins):
         "Test rebinning data in the experiment"
         # WHEN
 
         # THEN
-        experiment.rebin({'Q': new_Q_bins, 'energy': new_energy_bins})
+        experiment.rebin({"Q": new_Q_bins, "energy": new_energy_bins})
 
         # EXPECT
         rebinned_data = experiment.binned_data
-        assert rebinned_data.sizes['Q'] == 6
-        assert rebinned_data.sizes['energy'] == 7
+        assert rebinned_data.sizes["Q"] == 6
+        assert rebinned_data.sizes["energy"] == 7
 
     def test_rebin_no_data_raises(self):
         "Test rebinning data when no data is present"
@@ -236,34 +236,34 @@ class TestExperiment:
 
         # THEN EXPECT
         with pytest.raises(ValueError):
-            experiment.rebin({'Q': 6, 'energy': 7})
+            experiment.rebin({"Q": 6, "energy": 7})
 
     def test_rebin_invalid_dimensions_raises(self, experiment):
         "Test rebinning data with invalid dimensions"
         # WHEN / THEN EXPECT
         with pytest.raises(TypeError):
-            experiment.rebin('invalid_dimensions')
+            experiment.rebin("invalid_dimensions")
 
     def test_rebin_invalid_dimension_name_raises(self, experiment):
         "Test rebinning data with invalid dimension name"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match='Dimension keys must be strings'):
-            experiment.rebin({123: 6, 'energy': 7})
+        with pytest.raises(TypeError, match="Dimension keys must be strings"):
+            experiment.rebin({123: 6, "energy": 7})
 
     def test_rebin_dimension_not_in_data_raises(self, experiment):
         "Test rebinning data with a dimension not in the data"
         # WHEN / THEN EXPECT
         with pytest.raises(KeyError, match="Dimension 'time' not a valid"):
-            experiment.rebin({'time': 6, 'energy': 7})
+            experiment.rebin({"time": 6, "energy": 7})
 
     def test_rebin_invalid_bin_values_raises(self, experiment):
         "Test rebinning data with invalid bin values"
         # WHEN / THEN EXPECT
         with pytest.raises(
             TypeError,
-            match='Dimension values must be integers or',
+            match="Dimension values must be integers or",
         ):
-            experiment.rebin({'Q': [0.5, 1.0, 1.5], 'energy': 7})
+            experiment.rebin({"Q": [0.5, 1.0, 1.5], "energy": 7})
 
     ##############
     # test setters and getters
@@ -293,6 +293,45 @@ class TestExperiment:
         with pytest.raises(AttributeError):
             experiment.Q = experiment.Q
 
+    def test_get_masked_energy(self, experiment_with_data):
+        "Test getting masked energy"
+        # WHEN
+        Q_index = 0
+        invalid_data = experiment_with_data._data.copy()
+        invalid_data.data.values[Q_index][0] = np.inf
+        invalid_data.data.variances[Q_index][1] = np.nan
+
+        experiment_with_data.data = invalid_data
+
+        # THEN
+        masked_energy = experiment_with_data.get_masked_energy(Q_index=Q_index)
+
+        # EXPECT
+        len(masked_energy) == 1
+        assert masked_energy.values == 30.0
+
+    def test_get_masked_energy_no_data_returns_None(self, experiment):
+        "Test getting masked energy returns zero when no data is present"
+
+        # WHEN THEN
+        masked_energy = experiment.get_masked_energy(Q_index=0)
+
+        # EXPECT
+        assert masked_energy is None
+
+    @pytest.mark.parametrize(
+        "Q_index",
+        [-1, 100, "not an index"],
+        ids=["negative_index", "out_of_bounds_index", "invalid_type"],
+    )
+    def test_get_masked_energy_invalid_Q_index_raises(
+        self, experiment_with_data, Q_index
+    ):
+        "Test getting masked energy raises IndexError when Q index is invalid"
+        # WHEN THEN EXPECT
+        with pytest.raises(IndexError):
+            experiment_with_data.get_masked_energy(Q_index=Q_index)
+
     ##############
     # test plotting
     ##############
@@ -301,8 +340,8 @@ class TestExperiment:
         "Test plotting data successfully when in notebook environment"
         # WHEN
         with (
-            patch(f'{Experiment.__module__}._in_notebook', return_value=True),
-            patch('plopp.plot') as mock_plot,
+            patch(f"{Experiment.__module__}._in_notebook", return_value=True),
+            patch("plopp.plot") as mock_plot,
         ):
             mock_fig = MagicMock()
             mock_plot.return_value = mock_fig
@@ -314,7 +353,7 @@ class TestExperiment:
             mock_plot.assert_called_once()
             args, kwargs = mock_plot.call_args
             assert sc.identical(args[0], experiment._data.transpose())
-            assert kwargs['title'] == f'{experiment.display_name}'
+            assert kwargs["title"] == f"{experiment.display_name}"
             assert result == mock_fig
 
     def test_plot_data_no_data_raises(self):
@@ -323,18 +362,18 @@ class TestExperiment:
         experiment = Experiment()
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match='No data to plot'):
+        with pytest.raises(ValueError, match="No data to plot"):
             experiment.plot_data()
 
     def test_plot_data_not_in_notebook_raises(self, experiment):
         "Test plotting data raises RuntimeError"
-        'when not in notebook environment'
+        "when not in notebook environment"
         # WHEN
-        with patch(f'{Experiment.__module__}._in_notebook', return_value=False):
+        with patch(f"{Experiment.__module__}._in_notebook", return_value=False):
             # THEN EXPECT
             with pytest.raises(
                 RuntimeError,
-                match='plot_data\\(\\) can only be used in a Jupyter notebook environment',
+                match="plot_data\\(\\) can only be used in a Jupyter notebook environment",
             ):
                 experiment.plot_data()
 
@@ -349,40 +388,42 @@ class TestExperiment:
 
     def test_validate_coordinates_raises_missing_Q(self, experiment):
         "Test that _validate_coordinates raises ValueError when Q coord"
-        'is missing'
+        "is missing"
         # WHEN
         invalid_data = experiment._data.copy()
-        invalid_data.coords.pop('Q')
+        invalid_data.coords.pop("Q")
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match='missing required coordinate'):
+        with pytest.raises(ValueError, match="missing required coordinate"):
             experiment._validate_coordinates(invalid_data)
 
     def test_validate_coordinates_raises_missing_energy(self, experiment):
         "Test that _validate_coordinates raises ValueError when energy"
-        'coord is missing'
+        "coord is missing"
         # WHEN
         invalid_data = experiment._data.copy()
-        invalid_data.coords.pop('energy')
+        invalid_data.coords.pop("energy")
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match='missing required coordinate'):
+        with pytest.raises(ValueError, match="missing required coordinate"):
             experiment._validate_coordinates(invalid_data)
 
     def test_validate_coordinates_raises_not_DataArray(self):
         "Test that _validate_coordinates raises TypeError when data is"
-        'not a Scipp DataArray'
+        "not a Scipp DataArray"
         # WHEN THEN EXPECT
-        with pytest.raises(TypeError, match='must be a'):
-            Experiment()._validate_coordinates('not_a_data_array')
+        with pytest.raises(TypeError, match="must be a"):
+            Experiment()._validate_coordinates("not_a_data_array")
 
     def test_convert_to_bin_centers(self, experiment):
         "Test that _convert_to_bin_centers converts edges to centers"
         # WHEN
-        Q_edges = sc.linspace('Q', 0.0, 2.0, num=11, unit='1/Angstrom')
-        energy_edges = sc.linspace('energy', -6, 6, num=13, unit='meV')
-        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 12)))
-        binned_data = sc.DataArray(data=values, coords={'Q': Q_edges, 'energy': energy_edges})
+        Q_edges = sc.linspace("Q", 0.0, 2.0, num=11, unit="1/Angstrom")
+        energy_edges = sc.linspace("energy", -6, 6, num=13, unit="meV")
+        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 12)))
+        binned_data = sc.DataArray(
+            data=values, coords={"Q": Q_edges, "energy": energy_edges}
+        )
 
         # THEN
         experiment._data = binned_data  # Set data to avoid warnings
@@ -392,8 +433,8 @@ class TestExperiment:
         expected_Q = 0.5 * (Q_edges[:-1] + Q_edges[1:])
         expected_energy = 0.5 * (energy_edges[:-1] + energy_edges[1:])
 
-        assert sc.identical(converted_data.coords['Q'], expected_Q)
-        assert sc.identical(converted_data.coords['energy'], expected_energy)
+        assert sc.identical(converted_data.coords["Q"], expected_Q)
+        assert sc.identical(converted_data.coords["energy"], expected_energy)
         assert sc.identical(converted_data.data, binned_data.data)
 
     def test_extract_x_y_e(self, experiment_with_data):
@@ -422,8 +463,12 @@ class TestExperiment:
         invalid_data.data.variances[Q_index][0] = np.nan
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match='Cannot compute weights: some variances are zero'):
-            Experiment(data=invalid_data)._extract_x_y_weights_only_finite(Q_index=Q_index)
+        with pytest.raises(
+            ValueError, match="Cannot compute weights: some variances are zero"
+        ):
+            Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
+                Q_index=Q_index
+            )
 
     def test_extract_x_y_weights_only_finite(self, experiment_with_data):
         "Test that _extract_x_y_weights_only_finite only returns finite values"
@@ -434,15 +479,17 @@ class TestExperiment:
         invalid_data.data.variances[Q_index][1] = np.nan
 
         # THEN
-        x, y, weights, mask = Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
-            Q_index=Q_index
-        )
+        x, y, weights, mask = Experiment(
+            data=invalid_data
+        )._extract_x_y_weights_only_finite(Q_index=Q_index)
 
         # EXPECT
         assert np.isfinite(x).all()
         assert np.isfinite(y).all()
         assert np.isfinite(weights).all()
-        assert weights[0] == 1.0 / (experiment_with_data.data.variances[Q_index][2] ** 0.5)
+        assert weights[0] == 1.0 / (
+            experiment_with_data.data.variances[Q_index][2] ** 0.5
+        )
         assert len(x) == len(y) == len(weights) == 1  # 2 values should be removed
         # Mask should indicate which values were removed
         assert np.array_equal(mask, [False, False, True])
@@ -456,12 +503,15 @@ class TestExperiment:
         repr_str = repr(experiment)
 
         # THEN EXPECT
-        assert repr_str == f'Experiment `{experiment.unique_name}` with data: {experiment._data}'
+        assert (
+            repr_str
+            == f"Experiment `{experiment.unique_name}` with data: {experiment._data}"
+        )
 
     def test_copy_experiment(self, experiment):
         "Test copying an Experiment object."
-        'The copied object should have the same attributes '
-        'but be a different object in memory.'
+        "The copied object should have the same attributes "
+        "but be a different object in memory."
         # WHEN
         copied_experiment = copy(experiment)
 

--- a/tests/unit/easydynamics/experiment/test_experiment.py
+++ b/tests/unit/easydynamics/experiment/test_experiment.py
@@ -15,26 +15,26 @@ from easydynamics.experiment import Experiment
 class TestExperiment:
     @pytest.fixture
     def experiment(self):
-        Q = sc.linspace("Q", 0.5, 1.5, num=10, unit="1/Angstrom")
-        energy = sc.linspace("energy", -5, 5, num=11, unit="meV")
-        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 11)))
-        data = sc.DataArray(data=values, coords={"Q": Q, "energy": energy})
+        Q = sc.linspace('Q', 0.5, 1.5, num=10, unit='1/Angstrom')
+        energy = sc.linspace('energy', -5, 5, num=11, unit='meV')
+        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 11)))
+        data = sc.DataArray(data=values, coords={'Q': Q, 'energy': energy})
 
-        experiment = Experiment(display_name="test_experiment", data=data)
+        experiment = Experiment(display_name='test_experiment', data=data)
         return experiment
 
     @pytest.fixture
     def experiment_with_data(self):
         "Fixture that provides an Experiment with data for testing methods that require data"
-        Q = sc.array(dims=["Q"], values=[1, 2, 3], unit="1/Angstrom")
-        energy = sc.array(dims=["energy"], values=[10.0, 20.0, 30.0], unit="meV")
+        Q = sc.array(dims=['Q'], values=[1, 2, 3], unit='1/Angstrom')
+        energy = sc.array(dims=['energy'], values=[10.0, 20.0, 30.0], unit='meV')
         data = sc.array(
-            dims=["Q", "energy"],
+            dims=['Q', 'energy'],
             values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
             variances=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]],
         )
 
-        data_array = sc.DataArray(data=data, coords={"Q": Q, "energy": energy})
+        data_array = sc.DataArray(data=data, coords={'Q': Q, 'energy': energy})
 
         experiment = Experiment(data=data_array)
 
@@ -47,51 +47,51 @@ class TestExperiment:
     def test_init_array(self, experiment):
         "Test initialization with a Scipp DataArray"
         # WHEN THEN EXPECT
-        assert experiment.display_name == "test_experiment"
+        assert experiment.display_name == 'test_experiment'
         assert isinstance(experiment._data, sc.DataArray)
-        assert "Q" in experiment._data.dims
-        assert "energy" in experiment._data.dims
-        assert experiment._data.sizes["Q"] == 10
-        assert experiment._data.sizes["energy"] == 11
+        assert 'Q' in experiment._data.dims
+        assert 'energy' in experiment._data.dims
+        assert experiment._data.sizes['Q'] == 10
+        assert experiment._data.sizes['energy'] == 11
         assert sc.identical(
             experiment._data.data,
-            sc.array(dims=["Q", "energy"], values=np.ones((10, 11))),
+            sc.array(dims=['Q', 'energy'], values=np.ones((10, 11))),
         )
 
     def test_init_string(self, tmp_path):
         "Test initialization with a filename string,"
-        "should load the file"
+        'should load the file'
         # WHEN
-        Q = sc.linspace("Q", 0.5, 1.5, num=10, unit="1/Angstrom")
-        energy = sc.linspace("energy", -5, 5, num=11, unit="meV")
-        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 11)))
-        data = sc.DataArray(data=values, coords={"Q": Q, "energy": energy})
+        Q = sc.linspace('Q', 0.5, 1.5, num=10, unit='1/Angstrom')
+        energy = sc.linspace('energy', -5, 5, num=11, unit='meV')
+        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 11)))
+        data = sc.DataArray(data=values, coords={'Q': Q, 'energy': energy})
 
-        filename = tmp_path / "test_experiment.h5"
+        filename = tmp_path / 'test_experiment.h5'
         sc.io.save_hdf5(data, filename)
 
         # THEN
-        experiment = Experiment(display_name="loaded_experiment", data=str(filename))
+        experiment = Experiment(display_name='loaded_experiment', data=str(filename))
 
         # EXPECT
-        assert experiment.display_name == "loaded_experiment"
+        assert experiment.display_name == 'loaded_experiment'
         assert isinstance(experiment._data, sc.DataArray)
-        assert "Q" in experiment._data.dims
-        assert "energy" in experiment._data.dims
-        assert experiment._data.sizes["Q"] == 10
-        assert experiment._data.sizes["energy"] == 11
+        assert 'Q' in experiment._data.dims
+        assert 'energy' in experiment._data.dims
+        assert experiment._data.sizes['Q'] == 10
+        assert experiment._data.sizes['energy'] == 11
         assert sc.identical(
             experiment._data.data,
-            sc.array(dims=["Q", "energy"], values=np.ones((10, 11))),
+            sc.array(dims=['Q', 'energy'], values=np.ones((10, 11))),
         )
 
     def test_init_no_data(self):
         "Test initialization with no data"
         # WHEN
-        experiment = Experiment(display_name="empty_experiment")
+        experiment = Experiment(display_name='empty_experiment')
 
         # THEN EXPECT
-        assert experiment.display_name == "empty_experiment"
+        assert experiment.display_name == 'empty_experiment'
         assert experiment._data is None
         assert experiment.energy is None
         assert experiment.Q is None
@@ -108,34 +108,34 @@ class TestExperiment:
 
     def test_load_hdf5(self, tmp_path, experiment):
         "Test loading data from an HDF5 file."
-        "First use scipp to save data to a file, "
-        "then load it using the method."
+        'First use scipp to save data to a file, '
+        'then load it using the method.'
         # WHEN
         # First create a file to load from
-        filename = tmp_path / "test.h5"
+        filename = tmp_path / 'test.h5'
         data_to_save = experiment.data
         sc.io.save_hdf5(data_to_save, filename)
 
         # THEN
-        new_experiment = Experiment(display_name="new_experiment")
-        new_experiment.load_hdf5(str(filename), display_name="loaded_data")
+        new_experiment = Experiment(display_name='new_experiment')
+        new_experiment.load_hdf5(str(filename), display_name='loaded_data')
         loaded_data = new_experiment.data
 
         # EXPECT
         assert sc.identical(data_to_save, loaded_data)
-        assert new_experiment.display_name == "loaded_data"
+        assert new_experiment.display_name == 'loaded_data'
 
     def test_load_hdf5_invalid_name_raises(self, experiment):
         "Test loading data from an HDF5 file,"
-        "giving the Experiment an invalid name"
+        'giving the Experiment an invalid name'
         # WHEN / THEN EXPECT
         with pytest.raises(TypeError):
-            experiment.load_hdf5("some_file.h5", display_name=123)
+            experiment.load_hdf5('some_file.h5', display_name=123)
 
     def test_load_hdf5_invalid_filename_raises(self, experiment):
         "Test loading data from an HDF5 file with an invalid filename"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match="must be a string"):
+        with pytest.raises(TypeError, match='must be a string'):
             experiment.load_hdf5(123)
 
     def test_load_hdf5_invalid_file_raises(self, experiment):
@@ -143,13 +143,13 @@ class TestExperiment:
         # WHEN / THEN EXPECT
 
         with pytest.raises(OSError):
-            experiment.load_hdf5("non_existent_file.h5")
+            experiment.load_hdf5('non_existent_file.h5')
 
     def test_save_hdf5(self, tmp_path, experiment):
         "Test saving data to an HDF5 file. Load the saved file"
-        "using scipp and compare to the original data."
+        'using scipp and compare to the original data.'
         # WHEN THEN
-        filename = tmp_path / "saved_data.h5"
+        filename = tmp_path / 'saved_data.h5'
         experiment.save_hdf5(str(filename))
 
         # EXPECT
@@ -166,25 +166,25 @@ class TestExperiment:
         experiment.save_hdf5()
 
         # EXPECT
-        expected_filename = tmp_path / f"{experiment.unique_name}.h5"
+        expected_filename = tmp_path / f'{experiment.unique_name}.h5'
         loaded_data = sc.io.load_hdf5(str(expected_filename))
         original_data = experiment.data
         assert sc.identical(original_data, loaded_data)
 
     def test_save_hdf5_no_data_raises(self):
         "Test saving data to an HDF5 file when no data is present"
-        "in the experiment"
+        'in the experiment'
         # WHEN
         experiment = Experiment()
 
         # THEN EXPECT
         with pytest.raises(ValueError):
-            experiment.save_hdf5("should_fail.h5")
+            experiment.save_hdf5('should_fail.h5')
 
     def test_save_hdf5_invalid_filename_raises(self, experiment):
         "Test saving data to an HDF5 file with an invalid filename"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match="must be a string"):
+        with pytest.raises(TypeError, match='must be a string'):
             experiment.save_hdf5(123)
 
     def test_remove_data(self, experiment):
@@ -196,11 +196,11 @@ class TestExperiment:
         assert experiment._data is None
 
     @pytest.mark.parametrize(
-        "new_Q_bins, new_energy_bins",
+        'new_Q_bins, new_energy_bins',
         [
             (
-                sc.linspace("Q", 0.5, 1.5, num=7, unit="1/Angstrom"),
-                sc.linspace("energy", -5, 5, num=8, unit="meV"),
+                sc.linspace('Q', 0.5, 1.5, num=7, unit='1/Angstrom'),
+                sc.linspace('energy', -5, 5, num=8, unit='meV'),
             ),
             (
                 6,
@@ -211,23 +211,23 @@ class TestExperiment:
                 7.0,
             ),
             (
-                sc.linspace("Q", 0.5, 1.5, num=7, unit="1/Angstrom"),
+                sc.linspace('Q', 0.5, 1.5, num=7, unit='1/Angstrom'),
                 7,
             ),
         ],
-        ids=["sc_bins", "integers_bins", "float_bins", "mixed_bins"],
+        ids=['sc_bins', 'integers_bins', 'float_bins', 'mixed_bins'],
     )
     def test_rebin(self, experiment, new_Q_bins, new_energy_bins):
         "Test rebinning data in the experiment"
         # WHEN
 
         # THEN
-        experiment.rebin({"Q": new_Q_bins, "energy": new_energy_bins})
+        experiment.rebin({'Q': new_Q_bins, 'energy': new_energy_bins})
 
         # EXPECT
         rebinned_data = experiment.binned_data
-        assert rebinned_data.sizes["Q"] == 6
-        assert rebinned_data.sizes["energy"] == 7
+        assert rebinned_data.sizes['Q'] == 6
+        assert rebinned_data.sizes['energy'] == 7
 
     def test_rebin_no_data_raises(self):
         "Test rebinning data when no data is present"
@@ -236,34 +236,34 @@ class TestExperiment:
 
         # THEN EXPECT
         with pytest.raises(ValueError):
-            experiment.rebin({"Q": 6, "energy": 7})
+            experiment.rebin({'Q': 6, 'energy': 7})
 
     def test_rebin_invalid_dimensions_raises(self, experiment):
         "Test rebinning data with invalid dimensions"
         # WHEN / THEN EXPECT
         with pytest.raises(TypeError):
-            experiment.rebin("invalid_dimensions")
+            experiment.rebin('invalid_dimensions')
 
     def test_rebin_invalid_dimension_name_raises(self, experiment):
         "Test rebinning data with invalid dimension name"
         # WHEN / THEN EXPECT
-        with pytest.raises(TypeError, match="Dimension keys must be strings"):
-            experiment.rebin({123: 6, "energy": 7})
+        with pytest.raises(TypeError, match='Dimension keys must be strings'):
+            experiment.rebin({123: 6, 'energy': 7})
 
     def test_rebin_dimension_not_in_data_raises(self, experiment):
         "Test rebinning data with a dimension not in the data"
         # WHEN / THEN EXPECT
         with pytest.raises(KeyError, match="Dimension 'time' not a valid"):
-            experiment.rebin({"time": 6, "energy": 7})
+            experiment.rebin({'time': 6, 'energy': 7})
 
     def test_rebin_invalid_bin_values_raises(self, experiment):
         "Test rebinning data with invalid bin values"
         # WHEN / THEN EXPECT
         with pytest.raises(
             TypeError,
-            match="Dimension values must be integers or",
+            match='Dimension values must be integers or',
         ):
-            experiment.rebin({"Q": [0.5, 1.0, 1.5], "energy": 7})
+            experiment.rebin({'Q': [0.5, 1.0, 1.5], 'energy': 7})
 
     ##############
     # test setters and getters
@@ -310,9 +310,10 @@ class TestExperiment:
         len(masked_energy) == 1
         assert masked_energy.values == 30.0
 
-    def test_get_masked_energy_no_data_returns_None(self, experiment):
+    def test_get_masked_energy_no_data_returns_None(self):
         "Test getting masked energy returns zero when no data is present"
 
+        experiment = Experiment()
         # WHEN THEN
         masked_energy = experiment.get_masked_energy(Q_index=0)
 
@@ -320,13 +321,11 @@ class TestExperiment:
         assert masked_energy is None
 
     @pytest.mark.parametrize(
-        "Q_index",
-        [-1, 100, "not an index"],
-        ids=["negative_index", "out_of_bounds_index", "invalid_type"],
+        'Q_index',
+        [-1, 100, 'not an index'],
+        ids=['negative_index', 'out_of_bounds_index', 'invalid_type'],
     )
-    def test_get_masked_energy_invalid_Q_index_raises(
-        self, experiment_with_data, Q_index
-    ):
+    def test_get_masked_energy_invalid_Q_index_raises(self, experiment_with_data, Q_index):
         "Test getting masked energy raises IndexError when Q index is invalid"
         # WHEN THEN EXPECT
         with pytest.raises(IndexError):
@@ -340,8 +339,8 @@ class TestExperiment:
         "Test plotting data successfully when in notebook environment"
         # WHEN
         with (
-            patch(f"{Experiment.__module__}._in_notebook", return_value=True),
-            patch("plopp.plot") as mock_plot,
+            patch(f'{Experiment.__module__}._in_notebook', return_value=True),
+            patch('plopp.plot') as mock_plot,
         ):
             mock_fig = MagicMock()
             mock_plot.return_value = mock_fig
@@ -353,7 +352,7 @@ class TestExperiment:
             mock_plot.assert_called_once()
             args, kwargs = mock_plot.call_args
             assert sc.identical(args[0], experiment._data.transpose())
-            assert kwargs["title"] == f"{experiment.display_name}"
+            assert kwargs['title'] == f'{experiment.display_name}'
             assert result == mock_fig
 
     def test_plot_data_no_data_raises(self):
@@ -362,18 +361,18 @@ class TestExperiment:
         experiment = Experiment()
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match="No data to plot"):
+        with pytest.raises(ValueError, match='No data to plot'):
             experiment.plot_data()
 
     def test_plot_data_not_in_notebook_raises(self, experiment):
         "Test plotting data raises RuntimeError"
-        "when not in notebook environment"
+        'when not in notebook environment'
         # WHEN
-        with patch(f"{Experiment.__module__}._in_notebook", return_value=False):
+        with patch(f'{Experiment.__module__}._in_notebook', return_value=False):
             # THEN EXPECT
             with pytest.raises(
                 RuntimeError,
-                match="plot_data\\(\\) can only be used in a Jupyter notebook environment",
+                match='plot_data\\(\\) can only be used in a Jupyter notebook environment',
             ):
                 experiment.plot_data()
 
@@ -388,42 +387,40 @@ class TestExperiment:
 
     def test_validate_coordinates_raises_missing_Q(self, experiment):
         "Test that _validate_coordinates raises ValueError when Q coord"
-        "is missing"
+        'is missing'
         # WHEN
         invalid_data = experiment._data.copy()
-        invalid_data.coords.pop("Q")
+        invalid_data.coords.pop('Q')
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match="missing required coordinate"):
+        with pytest.raises(ValueError, match='missing required coordinate'):
             experiment._validate_coordinates(invalid_data)
 
     def test_validate_coordinates_raises_missing_energy(self, experiment):
         "Test that _validate_coordinates raises ValueError when energy"
-        "coord is missing"
+        'coord is missing'
         # WHEN
         invalid_data = experiment._data.copy()
-        invalid_data.coords.pop("energy")
+        invalid_data.coords.pop('energy')
 
         # THEN EXPECT
-        with pytest.raises(ValueError, match="missing required coordinate"):
+        with pytest.raises(ValueError, match='missing required coordinate'):
             experiment._validate_coordinates(invalid_data)
 
     def test_validate_coordinates_raises_not_DataArray(self):
         "Test that _validate_coordinates raises TypeError when data is"
-        "not a Scipp DataArray"
+        'not a Scipp DataArray'
         # WHEN THEN EXPECT
-        with pytest.raises(TypeError, match="must be a"):
-            Experiment()._validate_coordinates("not_a_data_array")
+        with pytest.raises(TypeError, match='must be a'):
+            Experiment()._validate_coordinates('not_a_data_array')
 
     def test_convert_to_bin_centers(self, experiment):
         "Test that _convert_to_bin_centers converts edges to centers"
         # WHEN
-        Q_edges = sc.linspace("Q", 0.0, 2.0, num=11, unit="1/Angstrom")
-        energy_edges = sc.linspace("energy", -6, 6, num=13, unit="meV")
-        values = sc.array(dims=["Q", "energy"], values=np.ones((10, 12)))
-        binned_data = sc.DataArray(
-            data=values, coords={"Q": Q_edges, "energy": energy_edges}
-        )
+        Q_edges = sc.linspace('Q', 0.0, 2.0, num=11, unit='1/Angstrom')
+        energy_edges = sc.linspace('energy', -6, 6, num=13, unit='meV')
+        values = sc.array(dims=['Q', 'energy'], values=np.ones((10, 12)))
+        binned_data = sc.DataArray(data=values, coords={'Q': Q_edges, 'energy': energy_edges})
 
         # THEN
         experiment._data = binned_data  # Set data to avoid warnings
@@ -433,24 +430,24 @@ class TestExperiment:
         expected_Q = 0.5 * (Q_edges[:-1] + Q_edges[1:])
         expected_energy = 0.5 * (energy_edges[:-1] + energy_edges[1:])
 
-        assert sc.identical(converted_data.coords["Q"], expected_Q)
-        assert sc.identical(converted_data.coords["energy"], expected_energy)
+        assert sc.identical(converted_data.coords['Q'], expected_Q)
+        assert sc.identical(converted_data.coords['energy'], expected_energy)
         assert sc.identical(converted_data.data, binned_data.data)
 
-    def test_extract_x_y_e(self, experiment_with_data):
+    def test_extract_x_y_var(self, experiment_with_data):
         # WHEN
 
         Q_index = 0
 
         # THEN
-        x, y, e = experiment_with_data._extract_x_y_e(Q_index=Q_index)
+        x, y, var = experiment_with_data._extract_x_y_var(Q_index=Q_index)
 
         # EXPECT
         assert np.array_equal(x, experiment_with_data.energy.values)
         assert np.array_equal(y, experiment_with_data.data.values[Q_index])
         assert np.array_equal(
-            e,
-            experiment_with_data.data.variances[Q_index] ** 0.5,
+            var,
+            experiment_with_data.data.variances[Q_index],
         )
 
     def test_extract_x_y_weights_only_finite_zero_variances(self, experiment_with_data):
@@ -463,12 +460,8 @@ class TestExperiment:
         invalid_data.data.variances[Q_index][0] = np.nan
 
         # THEN EXPECT
-        with pytest.raises(
-            ValueError, match="Cannot compute weights: some variances are zero"
-        ):
-            Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
-                Q_index=Q_index
-            )
+        with pytest.raises(ValueError, match='Cannot compute weights: some variances are zero'):
+            Experiment(data=invalid_data)._extract_x_y_weights_only_finite(Q_index=Q_index)
 
     def test_extract_x_y_weights_only_finite(self, experiment_with_data):
         "Test that _extract_x_y_weights_only_finite only returns finite values"
@@ -479,20 +472,38 @@ class TestExperiment:
         invalid_data.data.variances[Q_index][1] = np.nan
 
         # THEN
-        x, y, weights, mask = Experiment(
-            data=invalid_data
-        )._extract_x_y_weights_only_finite(Q_index=Q_index)
+        x, y, weights, mask = Experiment(data=invalid_data)._extract_x_y_weights_only_finite(
+            Q_index=Q_index
+        )
 
         # EXPECT
         assert np.isfinite(x).all()
         assert np.isfinite(y).all()
         assert np.isfinite(weights).all()
-        assert weights[0] == 1.0 / (
-            experiment_with_data.data.variances[Q_index][2] ** 0.5
-        )
+        assert weights[0] == 1.0 / (experiment_with_data.data.variances[Q_index][2] ** 0.5)
         assert len(x) == len(y) == len(weights) == 1  # 2 values should be removed
         # Mask should indicate which values were removed
         assert np.array_equal(mask, [False, False, True])
+
+    def test_extract_x_y_weights_only_finite_zero_variance(self, experiment_with_data):
+        "Test getting x y and weights when variances are None"
+        # WHEN
+        Q_index = 0
+        data = experiment_with_data._data.copy()
+        data.variances = None
+
+        experiment_with_data.data = data
+
+        # THEN
+        x, y, weights, mask = experiment_with_data._extract_x_y_weights_only_finite(
+            Q_index=Q_index
+        )
+
+        # EXPECT
+        assert np.array_equal(x, experiment_with_data.energy.values)
+        assert np.array_equal(y, experiment_with_data.data.values[Q_index])
+        assert np.array_equal(weights, np.ones_like(y))
+        assert np.array_equal(mask, np.isfinite(y) & np.isfinite(x))
 
     ##############
     # test dunder methods
@@ -503,15 +514,12 @@ class TestExperiment:
         repr_str = repr(experiment)
 
         # THEN EXPECT
-        assert (
-            repr_str
-            == f"Experiment `{experiment.unique_name}` with data: {experiment._data}"
-        )
+        assert repr_str == f'Experiment `{experiment.unique_name}` with data: {experiment._data}'
 
     def test_copy_experiment(self, experiment):
         "Test copying an Experiment object."
-        "The copied object should have the same attributes "
-        "but be a different object in memory."
+        'The copied object should have the same attributes '
+        'but be a different object in memory.'
         # WHEN
         copied_experiment = copy(experiment)
 


### PR DESCRIPTION
Ensures that the correct energies are used when calculating the model for plotting. Also allows users to input a finer energy grid to make the plot prettier. 

Closes #119 
