### PR TITLE
Unit overhaul 2/6: Centralize Q-index validation via verify_Q_index

### DIFF
--- a/src/easydynamics/analysis/analysis.py
+++ b/src/easydynamics/analysis/analysis.py
@@ -20,6 +20,7 @@ from easydynamics.settings.convolution_settings import ConvolutionSettings
 from easydynamics.settings.detailed_balance_settings import DetailedBalanceSettings
 from easydynamics.utils.plotting import slicerplot_with_residuals
 from easydynamics.utils.utils import _in_notebook
+from easydynamics.utils.utils import verify_Q_index
 
 
 class Analysis(AnalysisBase):
@@ -253,7 +254,7 @@ class Analysis(AnalysisBase):
         if Q_index is None:
             return [analysis.calculate(energy=energy) for analysis in self.analysis_list]
 
-        Q_index = self._verify_Q_index(Q_index)
+        verify_Q_index(Q_index=Q_index, Q=self.Q)
         return self.analysis_list[Q_index].calculate(energy=energy)
 
     def fit(
@@ -291,7 +292,7 @@ class Analysis(AnalysisBase):
                 'No Q values available for fitting. Please check the experiment data.'
             )
 
-        Q_index = self._verify_Q_index(Q_index)
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
 
         if fit_method == 'independent':
             if Q_index is not None:
@@ -347,9 +348,8 @@ class Analysis(AnalysisBase):
         InteractiveFigure
             A Plopp InteractiveFigure containing the plot of the data and model.
         """
-
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
         if Q_index is not None:
-            Q_index = self._verify_Q_index(Q_index)
             return self.analysis_list[Q_index].plot_data_and_model(
                 plot_components=plot_components,
                 add_background=add_background,
@@ -627,8 +627,8 @@ class Analysis(AnalysisBase):
             Index of the Q value to fix the energy offset for. If None, fixes the energy offset for
             all Q values.
         """
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
         if Q_index is not None:
-            Q_index = self._verify_Q_index(Q_index)
             self.analysis_list[Q_index].fix_energy_offset()
         else:
             for analysis in self.analysis_list:
@@ -645,8 +645,8 @@ class Analysis(AnalysisBase):
             Index of the Q value to free the energy offset for. If None, frees the energy offset
             for all Q values.
         """
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
         if Q_index is not None:
-            Q_index = self._verify_Q_index(Q_index)
             self.analysis_list[Q_index].free_energy_offset()
         else:
             for analysis in self.analysis_list:

--- a/src/easydynamics/analysis/analysis1d.py
+++ b/src/easydynamics/analysis/analysis1d.py
@@ -22,6 +22,7 @@ from easydynamics.settings.convolution_settings import ConvolutionSettings
 from easydynamics.settings.detailed_balance_settings import DetailedBalanceSettings
 from easydynamics.utils.detailed_balance import detailed_balance_factor
 from easydynamics.utils.plotting import slicerplot_with_residuals
+from easydynamics.utils.utils import verify_Q_index
 
 
 class Analysis1d(AnalysisBase):
@@ -119,7 +120,8 @@ class Analysis1d(AnalysisBase):
             extra_parameters=extra_parameters,
         )
 
-        self._Q_index = self._verify_Q_index(Q_index)
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
+        self._Q_index = Q_index
 
         if self._Q_index is not None and self.experiment is not None:
             masked_energy = self.experiment.get_masked_energy(Q_index=self._Q_index)
@@ -158,8 +160,8 @@ class Analysis1d(AnalysisBase):
         value : int | None
             The Q index.
         """
-
-        self._Q_index = self._verify_Q_index(value)
+        verify_Q_index(Q_index=value, Q=self.Q, allow_none=True)
+        self._Q_index = value
         self._on_Q_index_changed()
 
     #############

--- a/src/easydynamics/analysis/analysis_base.py
+++ b/src/easydynamics/analysis/analysis_base.py
@@ -494,37 +494,6 @@ class AnalysisBase(EasyDynamicsModelBase):
         For subclasses that implement convolution, this method can be overridden
         """
 
-    def _verify_Q_index(self, Q_index: int | None) -> int | None:
-        """
-        Verify that the Q index is valid.
-
-        Parameters
-        ----------
-        Q_index : int | None
-            The Q index to verify.
-
-        Raises
-        ------
-        TypeError
-            If Q_index is not an integer or None.
-        IndexError
-            If the Q index is not valid.
-
-        Returns
-        -------
-        int | None
-            The verified Q index.
-        """
-        if Q_index is None:
-            return None
-
-        if not isinstance(Q_index, int):
-            raise TypeError('Q_index must be an integer or None.')
-
-        if Q_index < 0 or (self.Q is not None and Q_index >= len(self.Q)):
-            raise IndexError('Q_index must be a valid index for the Q values.')
-        return Q_index
-
     def _verify_energy(self, energy: sc.Variable | None) -> sc.Variable | None:
         """
         Verify that the provided energy is the correct type.

--- a/src/easydynamics/experiment/experiment.py
+++ b/src/easydynamics/experiment/experiment.py
@@ -13,6 +13,7 @@ from scipp.io import save_hdf5 as sc_save_hdf5
 
 from easydynamics.base_classes.easydynamics_base import EasyDynamicsBase
 from easydynamics.utils.utils import _in_notebook
+from easydynamics.utils.utils import verify_Q_index
 
 
 class Experiment(EasyDynamicsBase):
@@ -239,11 +240,6 @@ class Experiment(EasyDynamicsBase):
         Q_index : int
             The Q index to get the masked energy values for.
 
-        Raises
-        ------
-        IndexError
-            If Q_index is not a valid index for the Q values.
-
         Returns
         -------
         sc.Variable | None
@@ -252,12 +248,7 @@ class Experiment(EasyDynamicsBase):
         if self.binned_data is None:
             return None
 
-        if (
-            not isinstance(Q_index, int)
-            or Q_index < 0
-            or (self.Q is not None and Q_index >= len(self.Q))
-        ):
-            raise IndexError('Q_index must be a valid index for the Q values.')
+        verify_Q_index(Q_index, self.Q)
 
         energy = self.binned_data.coords['energy']
         _, _, _, mask = self._extract_x_y_weights_only_finite(Q_index=Q_index)

--- a/src/easydynamics/sample_model/diffusion_model/delta_lorentz.py
+++ b/src/easydynamics/sample_model/diffusion_model/delta_lorentz.py
@@ -13,6 +13,7 @@ from easydynamics.sample_model.components import Lorentzian
 from easydynamics.sample_model.diffusion_model.diffusion_model_base import DiffusionModelBase
 from easydynamics.utils.utils import Numeric
 from easydynamics.utils.utils import Q_type
+from easydynamics.utils.utils import verify_Q_index
 
 MINIMUM_WIDTH = 1e-10  # To avoid division by zero
 
@@ -587,22 +588,9 @@ class DeltaLorentz(DiffusionModelBase):
         -------
         list[Parameter]
             List of independent variables in the model.
-
-        Raises
-        ------
-        ValueError
-            If Q_index is not None and is not a valid index for the Q values in the model.
         """
 
-        if Q_index is not None and (
-            not isinstance(Q_index, int)
-            or Q_index < 0
-            or Q_index >= len(self._component_collections)
-        ):
-            raise ValueError(
-                f'Q_index must be an integer between 0 and '
-                f'{len(self._component_collections) - 1}, or None.'
-            )
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
 
         variables = []
         if self._allow_Q_variation['A_0'] is True:
@@ -629,22 +617,9 @@ class DeltaLorentz(DiffusionModelBase):
         -------
         list[DescriptorNumber]
             List of all variables in the model.
-
-        Raises
-        ------
-        ValueError
-            If Q_index is not None and is not a valid index for the Q values in the model.
         """
 
-        if Q_index is not None and (
-            not isinstance(Q_index, int)
-            or Q_index < 0
-            or Q_index >= len(self._component_collections)
-        ):
-            raise ValueError(
-                f'Q_index must be an integer between 0 and '
-                f'{len(self._component_collections) - 1}, or None.'
-            )
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
 
         variables = self.get_global_variables()
         variables.extend(self.get_independent_variables(Q_index=Q_index))

--- a/src/easydynamics/sample_model/diffusion_model/diffusion_model_base.py
+++ b/src/easydynamics/sample_model/diffusion_model/diffusion_model_base.py
@@ -12,6 +12,7 @@ from easydynamics.sample_model.component_collection import ComponentCollection
 from easydynamics.utils.utils import Numeric
 from easydynamics.utils.utils import Q_type
 from easydynamics.utils.utils import _validate_and_convert_Q
+from easydynamics.utils.utils import verify_Q_index
 
 
 class DiffusionModelBase(EasyDynamicsModelBase):
@@ -305,21 +306,8 @@ class DiffusionModelBase(EasyDynamicsModelBase):
         -------
         list[Parameter]
             List of independent variables in the model.
-
-        Raises
-        ------
-        ValueError
-            If Q_index is not None and is not a valid index for the Q values in the model.
         """
-        if Q_index is not None and (
-            not isinstance(Q_index, int)
-            or Q_index < 0
-            or Q_index >= len(self._component_collections)
-        ):
-            raise ValueError(
-                f'Q_index must be an integer between 0 and '
-                f'{max(len(self._component_collections) - 1, 0)}, or None.'
-            )
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
 
         return []
 
@@ -337,22 +325,8 @@ class DiffusionModelBase(EasyDynamicsModelBase):
         -------
         list[Parameter]
             A list of all Parameters from the diffusion model.
-
-        Raises
-        ------
-        ValueError
-            If Q_index is out of bounds for the number of ComponentCollections.
         """
-
-        if Q_index is not None and (
-            not isinstance(Q_index, int)
-            or Q_index < 0
-            or Q_index >= len(self._component_collections)
-        ):
-            raise ValueError(
-                f'Q_index must be an integer between 0 and '
-                f'{max(len(self._component_collections) - 1, 0)}, or None.'
-            )
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
 
         variables = self.get_global_variables()
         variables.extend(self.get_independent_variables(Q_index))
@@ -464,29 +438,16 @@ class DiffusionModelBase(EasyDynamicsModelBase):
             The index of the desired ComponentCollection. If None, all ComponentCollections are
             returned.
 
-        Raises
-        ------
-        TypeError
-            If Q_index is not an int.
-        IndexError
-            If Q_index is out of bounds for the number of ComponentCollections.
-
         Returns
         -------
         ComponentCollection | list[ComponentCollection]
             The ComponentCollection at the specified Q index. If Q_index is None, a list of all
             ComponentCollections is returned.
         """
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
         if Q_index is None:
             return self._component_collections
 
-        if not isinstance(Q_index, int):
-            raise TypeError(f'Q_index must be an int, got {type(Q_index).__name__}')
-        if Q_index < 0 or Q_index >= len(self._component_collections):
-            raise IndexError(
-                f'Q_index {Q_index} is out of bounds for component collections '
-                f'of length {len(self._component_collections)}'
-            )
         return self._component_collections[Q_index]
 
     # ------------------------------------------------------------------

--- a/src/easydynamics/sample_model/instrument_model.py
+++ b/src/easydynamics/sample_model/instrument_model.py
@@ -15,6 +15,7 @@ from easydynamics.utils.utils import Numeric
 from easydynamics.utils.utils import Q_type
 from easydynamics.utils.utils import _validate_and_convert_Q
 from easydynamics.utils.utils import _validate_unit
+from easydynamics.utils.utils import verify_Q_index
 
 
 class InstrumentModel(NewBase):
@@ -395,13 +396,6 @@ class InstrumentModel(NewBase):
             The index of the Q value to get variables for. If None, get variables for all Q values.
 
 
-        Raises
-        ------
-        TypeError
-            If Q_index is not an int or None.
-        IndexError
-            If Q_index is out of bounds for the Q values in the InstrumentModel.
-
         Returns
         -------
         list[Parameter]
@@ -413,15 +407,10 @@ class InstrumentModel(NewBase):
             return []
 
         self._ensure_energy_offsets_current()
+        verify_Q_index(Q_index=Q_index, Q=self._Q, allow_none=True)
         if Q_index is None:
             variables = [self._energy_offsets[i] for i in range(len(self._Q))]
         else:
-            if not isinstance(Q_index, int):
-                raise TypeError(f'Q_index must be an int or None, got {type(Q_index).__name__}')
-            if Q_index < 0 or Q_index >= len(self._Q):
-                raise IndexError(
-                    f'Q_index {Q_index} is out of bounds for Q of length {len(self._Q)}'
-                )
             variables = [self._energy_offsets[Q_index]]
 
         variables.extend(self._background_model.get_all_variables(Q_index=Q_index))
@@ -458,10 +447,6 @@ class InstrumentModel(NewBase):
         ------
         ValueError
             If no Q values are set in the InstrumentModel.
-        IndexError
-            If Q_index is out of bounds.
-        TypeError
-            If Q_index is not an int or None.
 
         Returns
         -------
@@ -473,14 +458,9 @@ class InstrumentModel(NewBase):
             raise ValueError('No Q values are set in the InstrumentModel.')
 
         self._ensure_energy_offsets_current()
+        verify_Q_index(Q_index=Q_index, Q=self._Q, allow_none=True)
         if Q_index is None:
             return self._energy_offsets
-
-        if not isinstance(Q_index, int):
-            raise TypeError(f'Q_index must be an int or None, got {type(Q_index).__name__}')
-
-        if Q_index < 0 or Q_index >= len(self._Q):
-            raise IndexError(f'Q_index {Q_index} is out of bounds for Q of length {len(self._Q)}')
 
         return self._energy_offsets[Q_index]
 
@@ -531,27 +511,13 @@ class InstrumentModel(NewBase):
             energy offsets for all Q values.
         fixed : bool, default=True
             Whether to fix (True) or free (False) the energy offset.
-
-        Raises
-        ------
-        TypeError
-            If Q_index is not an int or None.
-        IndexError
-            If Q_index is out of bounds for the Q values in the InstrumentModel.
         """
-
         self._ensure_energy_offsets_current()
+        verify_Q_index(Q_index=Q_index, Q=self._Q, allow_none=True)
         if Q_index is None:
             for offset in self._energy_offsets:
                 offset.fixed = fixed
         else:
-            if not isinstance(Q_index, int):
-                raise TypeError(f'Q_index must be an int or None, got {type(Q_index).__name__}')
-
-            if Q_index < 0 or Q_index >= len(self._Q):
-                raise IndexError(
-                    f'Q_index {Q_index} is out of bounds for Q of length {len(self._Q)}'
-                )
             self._energy_offsets[Q_index].fixed = fixed
 
     def _ensure_energy_offsets_current(self) -> None:

--- a/src/easydynamics/sample_model/model_base.py
+++ b/src/easydynamics/sample_model/model_base.py
@@ -13,6 +13,7 @@ from easydynamics.sample_model.components.model_component import ModelComponent
 from easydynamics.utils.utils import Numeric
 from easydynamics.utils.utils import Q_type
 from easydynamics.utils.utils import _validate_and_convert_Q
+from easydynamics.utils.utils import verify_Q_index
 
 
 class ModelBase(EasyDynamicsModelBase):
@@ -314,21 +315,14 @@ class ModelBase(EasyDynamicsModelBase):
             If None, get variables for all ComponentCollections. If int, get variables for the
             ComponentCollection at this index.
 
-        Raises
-        ------
-        TypeError
-            If Q_index is not an int or None.
-        IndexError
-            If Q_index is out of bounds for the number of ComponentCollections.
-
         Returns
         -------
         list[Parameter]
             A list of all Parameters and Descriptors from the ComponentCollections in the
             ModelBase.
         """
-
         self._ensure_component_collections_current()
+        verify_Q_index(Q_index=Q_index, Q=self.Q, allow_none=True)
         if Q_index is None:
             all_vars = [
                 var
@@ -336,13 +330,6 @@ class ModelBase(EasyDynamicsModelBase):
                 for var in collection.get_all_variables()
             ]
         else:
-            if not isinstance(Q_index, int):
-                raise TypeError(f'Q_index must be an int or None, got {type(Q_index).__name__}')
-            if Q_index < 0 or Q_index >= len(self._component_collections):
-                raise IndexError(
-                    f'Q_index {Q_index} is out of bounds for component collections '
-                    f'of length {len(self._component_collections)}'
-                )
             all_vars = self._component_collections[Q_index].get_all_variables()
         return all_vars
 
@@ -355,26 +342,13 @@ class ModelBase(EasyDynamicsModelBase):
         Q_index : int
             The index of the desired ComponentCollection.
 
-        Raises
-        ------
-        TypeError
-            If Q_index is not an int.
-        IndexError
-            If Q_index is out of bounds for the number of ComponentCollections.
-
         Returns
         -------
         ComponentCollection
             The ComponentCollection at the given Q index.
         """
         self._ensure_component_collections_current()
-        if not isinstance(Q_index, int):
-            raise TypeError(f'Q_index must be an int, got {type(Q_index).__name__}')
-        if Q_index < 0 or Q_index >= len(self._component_collections):
-            raise IndexError(
-                f'Q_index {Q_index} is out of bounds for component collections '
-                f'of length {len(self._component_collections)}'
-            )
+        verify_Q_index(Q_index=Q_index, Q=self.Q)
         return self._component_collections[Q_index]
 
     def normalize_area(self) -> None:

--- a/tests/unit/easydynamics/analysis/test_analysis.py
+++ b/tests/unit/easydynamics/analysis/test_analysis.py
@@ -152,7 +152,7 @@ class TestAnalysis:
         # WHEN / THEN / EXPECT
         with pytest.raises(
             IndexError,
-            match='must be a valid index',
+            match='Q_index 3 is out of bounds',
         ):
             analysis.calculate(Q_index=3)
 
@@ -757,7 +757,7 @@ class TestAnalysis:
         # WHEN / THEN / EXPECT
         with pytest.raises(
             IndexError,
-            match='must be a valid index',
+            match='Q_index 3 is out of bounds',
         ):
             analysis.fit(Q_index=3)
 

--- a/tests/unit/easydynamics/analysis/test_analysis1d.py
+++ b/tests/unit/easydynamics/analysis/test_analysis1d.py
@@ -75,8 +75,8 @@ class TestAnalysis1d:
     @pytest.mark.parametrize(
         'invalid_Q_index, expected_exception, expected_message',
         [
-            (-1, IndexError, 'Q_index must be'),
-            (10, IndexError, 'Q_index must be'),
+            (-1, IndexError, 'Q_index must be non-negative'),
+            (10, IndexError, 'Q_index 10 is out of bounds'),
             ('invalid', TypeError, 'Q_index must be '),
             (np.nan, TypeError, 'Q_index must be '),
             ([1, 2], TypeError, 'Q_index must be '),

--- a/tests/unit/easydynamics/analysis/test_analysis_base.py
+++ b/tests/unit/easydynamics/analysis/test_analysis_base.py
@@ -532,24 +532,6 @@ class TestAnalysisBase:
             analysis_base._on_instrument_model_changed()
             np.testing.assert_array_equal(analysis_base.instrument_model.Q, fake_Q)
 
-    def test_verify_Q_index_valid(self, analysis_base):
-        # WHEN
-        valid_Q_index = 0
-
-        # THEN
-        result = analysis_base._verify_Q_index(valid_Q_index)
-
-        # EXPECT
-        assert result == valid_Q_index
-
-    def test_verify_Q_index_invalid(self, analysis_base):
-        # WHEN
-        invalid_Q_index = -1
-
-        # THEN / EXPECT
-        with pytest.raises(IndexError, match='Q_index must be a valid index'):
-            analysis_base._verify_Q_index(invalid_Q_index)
-
     def test_repr(self, analysis_base):
         # WHEN
         repr_str = repr(analysis_base)

--- a/tests/unit/easydynamics/experiment/test_experiment.py
+++ b/tests/unit/easydynamics/experiment/test_experiment.py
@@ -319,14 +319,20 @@ class TestExperiment:
 
     @pytest.mark.parametrize(
         'Q_index',
-        [-1, 100, 'not an index'],
-        ids=['negative_index', 'out_of_bounds_index', 'invalid_type'],
+        [-1, 100],
+        ids=['negative_index', 'out_of_bounds_index'],
     )
     def test_get_masked_energy_invalid_Q_index_raises(self, experiment_with_data, Q_index):
-        "Test getting masked energy raises IndexError when Q index is invalid"
+        "Test getting masked energy raises IndexError when Q index is out of range"
         # WHEN THEN EXPECT
         with pytest.raises(IndexError):
             experiment_with_data.get_masked_energy(Q_index=Q_index)
+
+    def test_get_masked_energy_invalid_type_raises(self, experiment_with_data):
+        "Test getting masked energy raises TypeError when Q index is not an integer"
+        # WHEN THEN EXPECT
+        with pytest.raises(TypeError):
+            experiment_with_data.get_masked_energy(Q_index='not an index')
 
     ##############
     # test plotting

--- a/tests/unit/easydynamics/sample_model/diffusion_model/test_delta_lorentz.py
+++ b/tests/unit/easydynamics/sample_model/diffusion_model/test_delta_lorentz.py
@@ -504,11 +504,11 @@ class TestDeltaLorentz:
             assert 'A_0' in collection[1].area.dependency_expression
 
     @pytest.mark.parametrize(
-        'Q_index',
+        ('Q_index', 'expected_exception', 'expected_message'),
         [
-            -1,
-            100,
-            'string',
+            (-1, IndexError, r'Q_index must be non-negative'),
+            (100, IndexError, r'Q_index 100 is out of bounds'),
+            ('string', TypeError, r'Q_index must be an int or None, got str'),
         ],
         ids=[
             'negative index',
@@ -516,9 +516,11 @@ class TestDeltaLorentz:
             'non-integer index',
         ],
     )
-    def test_get_independent_variables_raises(self, delta_lorentz_model_with_Q, Q_index):
+    def test_get_independent_variables_raises(
+        self, delta_lorentz_model_with_Q, Q_index, expected_exception, expected_message
+    ):
         # WHEN THEN EXPECT
-        with pytest.raises(ValueError, match=r'Q_index must be an integer between 0 and'):
+        with pytest.raises(expected_exception, match=expected_message):
             delta_lorentz_model_with_Q.get_independent_variables(Q_index=Q_index)
 
     def test_get_all_variables_no_Q_index(self, delta_lorentz_model_with_Q):
@@ -578,10 +580,10 @@ class TestDeltaLorentz:
 
     def test_get_all_variables_invalid_Q_index(self, delta_lorentz_model_with_Q):
         # WHEN THEN EXPECT
-        with pytest.raises(ValueError, match='Q_index must be an integer between 0 and'):
+        with pytest.raises(IndexError, match='Q_index must be non-negative'):
             delta_lorentz_model_with_Q.get_all_variables(Q_index=-1)
 
-        with pytest.raises(ValueError, match='Q_index must be an integer between 0 and'):
+        with pytest.raises(IndexError, match=r'Q_index \d+ is out of bounds'):
             delta_lorentz_model_with_Q.get_all_variables(Q_index=len(delta_lorentz_model_with_Q.Q))
 
     @pytest.mark.parametrize(

--- a/tests/unit/easydynamics/sample_model/diffusion_model/test_diffusion_model_base.py
+++ b/tests/unit/easydynamics/sample_model/diffusion_model/test_diffusion_model_base.py
@@ -163,29 +163,34 @@ class TestDiffusionModelBase:
         assert independent_vars == []
 
     @pytest.mark.parametrize(
-        'Q_index',
+        ('Q_index', 'expected_exception', 'expected_message'),
         [
-            -1,
-            100,
-            'string',
+            (-1, IndexError, 'Q_index must be non-negative'),
+            ('string', TypeError, 'Q_index must be an int or None, got str'),
         ],
         ids=[
             'negative index',
-            'index too large',
             'non-integer index',
         ],
     )
-    def test_get_independent_variables_raises(self, diffusion_model, Q_index):
+    def test_get_independent_variables_raises(
+        self, diffusion_model, Q_index, expected_exception, expected_message
+    ):
         # WHEN THEN EXPECT
-        with pytest.raises(ValueError, match=r'Q_index must be an integer between 0 and'):
+        with pytest.raises(expected_exception, match=expected_message):
             diffusion_model.get_independent_variables(Q_index=Q_index)
 
+    def test_get_independent_variables_deferred_when_Q_is_none(self, diffusion_model):
+        # WHEN: Q is None, so the upper-bound check on Q_index is deferred
+        # THEN EXPECT: no exception, and no independent variables
+        assert diffusion_model.get_independent_variables(Q_index=100) == []
+
     @pytest.mark.parametrize(
-        'Q_index',
+        ('Q_index', 'expected_exception', 'expected_message'),
         [
-            -1,
-            100,
-            'string',
+            (-1, IndexError, 'Q_index must be non-negative'),
+            (100, IndexError, 'out of range'),
+            ('string', TypeError, 'Q_index must be an int or None, got str'),
         ],
         ids=[
             'negative index',
@@ -193,9 +198,11 @@ class TestDiffusionModelBase:
             'non-integer index',
         ],
     )
-    def test_get_all_variables_raises(self, diffusion_model, Q_index):
+    def test_get_all_variables_raises(
+        self, diffusion_model, Q_index, expected_exception, expected_message
+    ):
         # WHEN THEN EXPECT
-        with pytest.raises(ValueError, match=r'Q_index must be an integer between 0 and'):
+        with pytest.raises(expected_exception, match=expected_message):
             diffusion_model.get_all_variables(Q_index=Q_index)
 
     def test_create_component_collections_no_Q(self, diffusion_model):

--- a/tests/unit/easydynamics/sample_model/test_model_base.py
+++ b/tests/unit/easydynamics/sample_model/test_model_base.py
@@ -168,7 +168,7 @@ class TestModelBase:
         # WHEN / THEN / EXPECT
         with pytest.raises(
             IndexError,
-            match='Q_index 5 is out of bounds for component collections of length 3',
+            match='Q_index 5 is out of bounds for Q of length 3',
         ):
             model_base.get_all_variables(Q_index=5)
 


### PR DESCRIPTION
Replace the `AnalysisBase._verify_Q_index` method and the various inline `Q_index` type/bounds checks scattered across the model hierarchy with the shared `verify_Q_index` helper (added in the previous PR). Callers now delegate validation to a single function with consistent error messages and behavior (`TypeError` for non-int, `IndexError` for negative/out-of-range, upper-bound deferred when Q is None).

Migrated: `Analysis`, `Analysis1d`, `AnalysisBase`, `Experiment`, `ModelBase`, `InstrumentModel`, `DiffusionModelBase` and `DeltaLorentz`. Tests updated to the unified messages.

Net: 15 files, +71/−236 (removes duplicated validation blocks). All unit tests pass.

---

**Stack — splitting the monolithic "Unit system overhaul" (#217) into a reviewable series. Merge bottom-up:**

1. Add unit-conversion utilities and FitTarget → `develop` (#221)
2. **Centralize Q-index validation via `verify_Q_index`** → `split/01-unit-utils` (#222) *(this PR)*
3. Store Q as a scipp `Variable` in 1/angstrom → `split/02a-verify-q-index` (#223)
4. Separate model `unit` into `x_unit`/`y_unit` + update tutorials → `split/02b-q-variable` (#224)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
